### PR TITLE
stop importing fipsonly 

### DIFF
--- a/fips.go
+++ b/fips.go
@@ -1,5 +1,0 @@
-//go:build fips
-
-package channel
-
-import _ "crypto/tls/fipsonly"


### PR DESCRIPTION
…because it's now enforced with openssl build tag 'requirefips'