### PR TITLE
Reconnecting channel shouldn't allow changing ids. Fixes #242

### DIFF
--- a/reconnecting_dialer.go
+++ b/reconnecting_dialer.go
@@ -168,11 +168,16 @@ func (dialer *reconnectingDialer) sendHello(impl *reconnectingImpl) error {
 	if !result.Success {
 		return errors.New(result.Message)
 	}
-	impl.connectionId = string(response.Headers[ConnectionIdHeader])
-
-	if id, ok := response.GetStringHeader(IdHeader); ok {
-		impl.id = &identity.TokenId{Token: id}
+	if impl.connectionId == "" {
+		if id, ok := response.GetStringHeader(IdHeader); ok {
+			impl.id = &identity.TokenId{Token: id}
+		}
+	} else {
+		if id, ok := response.GetStringHeader(IdHeader); ok && id != impl.id.Token {
+			log.Warnf("reconnected underlay has different id [%s] than expected [%s]", id, impl.id.Token)
+		}
 	}
+	impl.connectionId = string(response.Headers[ConnectionIdHeader])
 
 	impl.headers.Store(response.Headers)
 


### PR DESCRIPTION
Prevents reconnecting channels from overwriting their identity on reconnect.
On the initial connect, the id is set from the hello response. On reconnect,
the id is preserved and a warning is logged if the server returns a different one.
Also bumps Go to 1.25, updates dependencies, and removes transwarp references.