### PR TITLE
Allow calling Load on an Options instance so we can tweak defaults. Fixes #241

### DIFF
--- a/options.go
+++ b/options.go
@@ -65,47 +65,55 @@ func DefaultConnectOptions() ConnectOptions {
 	}
 }
 
-// LoadOptions parses channel Options from a configuration map.
+// LoadOptions parses channel Options from a configuration map, starting from DefaultOptions.
 func LoadOptions(data map[interface{}]interface{}) (*Options, error) {
 	options := DefaultOptions()
+	if err := options.Load(data); err != nil {
+		return nil, err
+	}
+	return options, nil
+}
 
+// Load applies configuration values from the given map onto the Options instance.
+// This allows callers to adjust defaults before loading configuration.
+func (o *Options) Load(data map[interface{}]interface{}) error {
 	if value, found := data["outQueueSize"]; found {
 		if floatValue, ok := value.(float64); ok {
-			options.OutQueueSize = int(floatValue)
+			o.OutQueueSize = int(floatValue)
 		}
 	}
 
 	if value, found := data["maxQueuedConnects"]; found {
 		if intVal, ok := value.(int); ok {
-			options.MaxQueuedConnects = intVal
+			o.MaxQueuedConnects = intVal
 		}
 	}
 
 	if value, found := data["maxOutstandingConnects"]; found {
 		if intVal, ok := value.(int); ok {
-			options.MaxOutstandingConnects = intVal
+			o.MaxOutstandingConnects = intVal
 		}
 	}
 
 	if value, found := data["connectTimeoutMs"]; found {
 		if intVal, ok := value.(int); ok {
-			options.ConnectTimeout = time.Duration(intVal) * time.Millisecond
+			o.ConnectTimeout = time.Duration(intVal) * time.Millisecond
 		}
 	}
 
 	if value, found := data["writeTimeout"]; found {
 		if strVal, ok := value.(string); ok {
 			if d, err := time.ParseDuration(strVal); err == nil {
-				options.WriteTimeout = d
+				o.WriteTimeout = d
 			} else {
-				return nil, errors.Wrapf(err, "invalid value for writeTimeout: %v", value)
+				return errors.Wrapf(err, "invalid value for writeTimeout: %v", value)
 			}
 		} else {
-			return nil, errors.Errorf("invalid (non-string) value for writeTimeout: %v", value)
+			return errors.Errorf("invalid (non-string) value for writeTimeout: %v", value)
 		}
 	}
 
-	return options, nil
+	return nil
 }
 
 func (o Options) String() string {

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,97 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package channel
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadOptions(t *testing.T) {
+	req := require.New(t)
+
+	data := map[interface{}]interface{}{
+		"outQueueSize":           float64(10),
+		"maxQueuedConnects":      20,
+		"maxOutstandingConnects": 30,
+		"connectTimeoutMs":       500,
+		"writeTimeout":           "250ms",
+	}
+
+	options, err := LoadOptions(data)
+	req.NoError(err)
+	req.Equal(10, options.OutQueueSize)
+	req.Equal(20, options.MaxQueuedConnects)
+	req.Equal(30, options.MaxOutstandingConnects)
+	req.Equal(500*time.Millisecond, options.ConnectTimeout)
+	req.Equal(250*time.Millisecond, options.WriteTimeout)
+}
+
+func TestLoadOptionsDefaults(t *testing.T) {
+	req := require.New(t)
+
+	options, err := LoadOptions(map[interface{}]interface{}{})
+	req.NoError(err)
+	req.Equal(DefaultOutQueueSize, options.OutQueueSize)
+	req.Equal(DefaultQueuedConnects, options.MaxQueuedConnects)
+	req.Equal(DefaultOutstandingConnects, options.MaxOutstandingConnects)
+	req.Equal(DefaultConnectTimeout, options.ConnectTimeout)
+	req.Equal(time.Duration(0), options.WriteTimeout)
+}
+
+func TestLoadOnInstance(t *testing.T) {
+	req := require.New(t)
+
+	options := DefaultOptions()
+	options.OutQueueSize = 16
+	options.WriteTimeout = 500 * time.Millisecond
+
+	data := map[interface{}]interface{}{
+		"maxQueuedConnects": 100,
+	}
+
+	req.NoError(options.Load(data))
+
+	// overridden by Load
+	req.Equal(100, options.MaxQueuedConnects)
+
+	// preserved from pre-configured instance
+	req.Equal(16, options.OutQueueSize)
+	req.Equal(500*time.Millisecond, options.WriteTimeout)
+
+	// unchanged defaults
+	req.Equal(DefaultOutstandingConnects, options.MaxOutstandingConnects)
+	req.Equal(DefaultConnectTimeout, options.ConnectTimeout)
+}
+
+func TestLoadOptionsWriteTimeoutErrors(t *testing.T) {
+	req := require.New(t)
+
+	_, err := LoadOptions(map[interface{}]interface{}{
+		"writeTimeout": 123,
+	})
+	req.Error(err)
+	req.Contains(err.Error(), "invalid (non-string) value for writeTimeout")
+
+	_, err = LoadOptions(map[interface{}]interface{}{
+		"writeTimeout": "not-a-duration",
+	})
+	req.Error(err)
+	req.Contains(err.Error(), "invalid value for writeTimeout")
+}


### PR DESCRIPTION
Adds `(*Options).Load` method so callers can set custom defaults on an Options instance before applying configuration. `LoadOptions` delegates to `Load`, preserving backward compatibility.