### PR TITLE
Hide unexported *channelImpl behind an opaque Binder type

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -174,24 +174,39 @@ func (self *bindingImpl[S]) GetUserData() any {
 	return self.ch.userData
 }
 
-// MakeTypedBinder creates a binder function from a TypedBindHandler and senders.
-func MakeTypedBinder[S Senders](senders S, handler TypedBindHandler[S]) func(*channelImpl) error {
-	return func(ch *channelImpl) error {
+// Binder is an installed bind handler, produced by MakeBinder or MakeTypedBinder and
+// supplied to a channel via Config.Binder. It is opaque: consumers obtain one from the
+// factory functions rather than constructing it directly.
+type Binder struct {
+	fn func(*channelImpl) error
+}
+
+// bind runs the wrapped bind handler against the given channel. A zero Binder is a no-op.
+func (self Binder) bind(ch *channelImpl) error {
+	if self.fn == nil {
+		return nil
+	}
+	return self.fn(ch)
+}
+
+// MakeTypedBinder creates a Binder from a TypedBindHandler and senders.
+func MakeTypedBinder[S Senders](senders S, handler TypedBindHandler[S]) Binder {
+	return Binder{fn: func(ch *channelImpl) error {
 		if handler == nil {
 			return nil
 		}
 		binding := &bindingImpl[S]{ch: ch, senders: senders}
 		return handler.BindChannel(binding)
-	}
+	}}
 }
 
-// MakeBinder creates a binder function from a BindHandler.
-func MakeBinder(handler BindHandler) func(*channelImpl) error {
-	return func(ch *channelImpl) error {
+// MakeBinder creates a Binder from a BindHandler.
+func MakeBinder(handler BindHandler) Binder {
+	return Binder{fn: func(ch *channelImpl) error {
 		if handler == nil {
 			return nil
 		}
 		binding := &bindingImpl[Senders]{ch: ch, senders: ch.senders}
 		return handler.BindChannel(binding)
-	}
+	}}
 }

--- a/impl.go
+++ b/impl.go
@@ -55,7 +55,7 @@ func NextConnectionId() (string, error) {
 type Config struct {
 	LogicalName string
 	Options     *Options
-	Binder      func(ch *channelImpl) error
+	Binder      Binder
 	Underlay    Underlay
 
 	InjectUnderlayTypeIntoMessages bool
@@ -246,18 +246,16 @@ func NewChannel(config *Config) (Channel, error) {
 		impl.underlays.AddListener(l)
 	}
 
-	if config.Binder != nil {
-		if err := config.Binder(impl); err != nil {
-			if closeErr := impl.Close(); closeErr != nil {
-				pfxlog.ContextLogger(impl.Label()).WithError(closeErr).Warn("error closing channel after bind failure")
-			}
-			if closeErr := config.Underlay.Close(); closeErr != nil {
-				if !errors.Is(closeErr, net.ErrClosed) {
-					pfxlog.ContextLogger(impl.Label()).WithError(err).Warn("error closing underlay")
-				}
-			}
-			return nil, err
+	if err := config.Binder.bind(impl); err != nil {
+		if closeErr := impl.Close(); closeErr != nil {
+			pfxlog.ContextLogger(impl.Label()).WithError(closeErr).Warn("error closing channel after bind failure")
 		}
+		if closeErr := config.Underlay.Close(); closeErr != nil {
+			if !errors.Is(closeErr, net.ErrClosed) {
+				pfxlog.ContextLogger(impl.Label()).WithError(closeErr).Warn("error closing underlay")
+			}
+		}
+		return nil, err
 	}
 
 	// Add and start the first underlay (this triggers UnderlayAdded)


### PR DESCRIPTION
Fixes #247

## Problem

The exported `Config.Binder` field, and the return types of `MakeBinder` / `MakeTypedBinder`, named the unexported `channelImpl`:

```go
Binder func(ch *channelImpl) error
```

This trips `revive`/`golint` ("exported field uses an unexported type"), renders opaquely in godoc, and prevents consumers from naming the binder type (they can only assign a factory result inline). It is not a functional blocker, but it adds friction to the v4 -> v5 migration in sdk-golang and ziti.

## Change

Erase behind an exported opaque type instead of a func-of-unexported-type:

- New `Binder` struct wrapping an unexported `fn func(*channelImpl) error`.
- `MakeBinder` and `MakeTypedBinder[S]` now return `Binder`.
- `Config.Binder` is now of type `Binder`.
- The previous `if config.Binder != nil` guard is folded into `Binder.bind`, which is a no-op for a zero-value `Binder`, preserving existing behavior when no binder is configured.

The unexported `fn` field keeps `Binder` un-constructible by hand, so the factory functions remain the only entry points. No consumer call-site changes: `Config{Binder: channel.MakeBinder(h)}` and `MakeTypedBinder[S](...)` work identically; only the field/return type changed.

## Verification

- `go build ./...`
- `go vet .`
- `go test .`