### PR TITLE
Let DialPolicy (re)establish a grouped channel via isFirst

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -209,6 +209,9 @@ type Underlay interface {
 	SetWriteDeadline(time time.Time) error
 	GetLocalAddr() net.Addr
 	GetRemoteAddr() net.Addr
+	// CreatedAt returns the time at which the underlay was created. It is used to judge
+	// connection stability, e.g. for flap detection when an underlay is closed.
+	CreatedAt() time.Time
 }
 
 type classicUnderlay interface {

--- a/classic_impl.go
+++ b/classic_impl.go
@@ -19,11 +19,12 @@ package channel
 import (
 	"crypto/x509"
 	"fmt"
-	"github.com/openziti/transport/v2"
-	"github.com/pkg/errors"
 	"net"
 	"sync/atomic"
 	"time"
+
+	"github.com/openziti/transport/v2"
+	"github.com/pkg/errors"
 )
 
 type classicImpl struct {
@@ -34,6 +35,11 @@ type classicImpl struct {
 	closed       atomic.Bool
 	readF        readFunction
 	marshalF     marshalFunction
+	createdAt    time.Time
+}
+
+func (impl *classicImpl) CreatedAt() time.Time {
+	return impl.createdAt
 }
 
 func (impl *classicImpl) GetLocalAddr() net.Addr {
@@ -146,8 +152,9 @@ func newClassicImpl(messageStrategy MessageStrategy, peer transport.Conn, versio
 	}
 
 	return &classicImpl{
-		peer:     peer,
-		readF:    readF,
-		marshalF: marshalF,
+		peer:      peer,
+		readF:     readF,
+		marshalF:  marshalF,
+		createdAt: time.Now(),
 	}
 }

--- a/datagram_underlay.go
+++ b/datagram_underlay.go
@@ -20,10 +20,11 @@ import (
 	"bytes"
 	"crypto/x509"
 	"fmt"
-	"github.com/openziti/transport/v2"
 	"net"
 	"sync/atomic"
 	"time"
+
+	"github.com/openziti/transport/v2"
 )
 
 type readPacketFunction func(buf []byte) (*Message, error)
@@ -37,6 +38,11 @@ type DatagramUnderlay struct {
 	closed       atomic.Bool
 	readF        readPacketFunction
 	marshalF     marshalFunction
+	createdAt    time.Time
+}
+
+func (self *DatagramUnderlay) CreatedAt() time.Time {
+	return self.createdAt
 }
 
 func newDatagramUnderlay(messageStrategy MessageStrategy, peer transport.Conn, version uint32) classicUnderlay {
@@ -60,9 +66,10 @@ func newDatagramUnderlay(messageStrategy MessageStrategy, peer transport.Conn, v
 	}
 
 	return &DatagramUnderlay{
-		peer:     peer,
-		readF:    readF,
-		marshalF: marshalF,
+		peer:      peer,
+		readF:     readF,
+		marshalF:  marshalF,
+		createdAt: time.Now(),
 	}
 }
 

--- a/dial_policy.go
+++ b/dial_policy.go
@@ -31,8 +31,13 @@ import (
 // initial connection or a reconnect after all underlays were lost. A first connection must
 // set the IsFirstGroupConnection header so the remote MultiListener creates a new channel
 // rather than rejecting the underlay; subsequent underlays attach to the existing group.
+//
+// UnderlayClosed is invoked by the channel whenever an underlay is removed, with how long
+// the underlay lived. This lets the policy judge connection stability directly, e.g. for
+// flap detection, rather than inferring it from dial timing.
 type DialPolicy interface {
 	Dial(underlayType string, connectionId string, groupSecret []byte, isFirst bool, connectTimeout time.Duration, cancel <-chan struct{}) (Underlay, error)
+	UnderlayClosed(underlayType string, lifetime time.Duration)
 }
 
 // BackoffConfig controls exponential backoff behavior.
@@ -41,9 +46,9 @@ type BackoffConfig struct {
 	BaseDelay time.Duration
 	// MaxDelay is the maximum delay between attempts (default: 60s).
 	MaxDelay time.Duration
-	// MinStableDuration is how long a connection must live to be considered stable (default: 5s).
-	// If a new dial is requested before this duration has elapsed since the last success,
-	// the connection is treated as short-lived and backoff is applied.
+	// MinStableDuration is how long a connection must live to be considered stable (default: 30s).
+	// An underlay that closes before living this long is treated as short-lived and counts as
+	// a failure for backoff purposes.
 	MinStableDuration time.Duration
 	// MinDialInterval is the minimum time between dial attempts (default: 0, no limit).
 	// If a dial is requested before this interval has elapsed since the last dial,
@@ -55,17 +60,22 @@ type BackoffConfig struct {
 var DefaultBackoffConfig = BackoffConfig{
 	BaseDelay:         2 * time.Second,
 	MaxDelay:          time.Minute,
-	MinStableDuration: 5 * time.Second,
+	MinStableDuration: 30 * time.Second,
 }
 
 // BackoffDialPolicy wraps a DialUnderlayFactory with exponential backoff retry logic.
-// It tracks consecutive failures and detects short-lived connections.
+// Failed dials and short-lived connections (reported via UnderlayClosed) count as failures;
+// a connection that closes after a stable lifetime, or one that has demonstrably outlived
+// MinStableDuration, resets the failure count.
+// Accounting is intentionally global for the policy because all underlays dial the same
+// destination. A stable underlay is evidence that the destination is not globally flapping.
 type BackoffDialPolicy struct {
 	Dialer              DialUnderlayFactory
 	Backoff             BackoffConfig
 	mu                  sync.Mutex
 	consecutiveFailures uint32
-	lastSuccess         time.Time
+	lastDialSuccess     time.Time
+	lastNegativeEvent   time.Time
 	lastDialTime        time.Time
 	iteration           uint32
 }
@@ -86,23 +96,41 @@ func NewBackoffDialPolicyWithConfig(dialer DialUnderlayFactory, config BackoffCo
 	}
 }
 
-// recordStartDial evaluates the previous connection's lifetime at the start of a new dial.
-// If the last connection was short-lived (< MinStableDuration), it counts as a failure.
-// If it was stable, the failure count is reset.
-func (self *BackoffDialPolicy) recordStartDial() {
+// UnderlayClosed records the lifetime of a closed underlay. A short-lived underlay
+// (lifetime < MinStableDuration) counts as a failure for backoff purposes; a stable one
+// resets the failure count.
+func (self *BackoffDialPolicy) UnderlayClosed(underlayType string, lifetime time.Duration) {
 	self.mu.Lock()
 	defer self.mu.Unlock()
 
-	if self.lastSuccess.IsZero() {
-		return
-	}
-
-	if time.Since(self.lastSuccess) < self.Backoff.MinStableDuration {
+	if lifetime < self.Backoff.MinStableDuration {
 		self.consecutiveFailures++
+		self.lastNegativeEvent = time.Now()
+		pfxlog.Logger().WithField("underlayType", underlayType).
+			WithField("lifetime", lifetime).
+			WithField("consecutiveFailures", self.consecutiveFailures).
+			Info("short-lived underlay closed")
 	} else {
 		self.consecutiveFailures = 0
 	}
-	self.lastSuccess = time.Time{} // reset last success
+}
+
+// resetStaleFailures clears the failure count if the most recent successful dial postdates the
+// last negative event (dial failure or short-lived close) and has aged past MinStableDuration.
+// That connection has proven stable - if it had died young, the resulting UnderlayClosed call
+// would have moved lastNegativeEvent past it. This keeps failures from a past flap episode
+// from imposing backoff after a connection has settled.
+func (self *BackoffDialPolicy) resetStaleFailures() {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	if self.consecutiveFailures == 0 || self.lastDialSuccess.IsZero() {
+		return
+	}
+
+	if self.lastDialSuccess.After(self.lastNegativeEvent) && time.Since(self.lastDialSuccess) >= self.Backoff.MinStableDuration {
+		self.consecutiveFailures = 0
+	}
 }
 
 func (self *BackoffDialPolicy) getBackoffDelay() time.Duration {
@@ -121,16 +149,16 @@ func (self *BackoffDialPolicy) getBackoffDelay() time.Duration {
 func (self *BackoffDialPolicy) recordSuccess() {
 	self.mu.Lock()
 	defer self.mu.Unlock()
-	self.lastSuccess = time.Now()
-	// Don't reset consecutiveFailures yet — wait to see if connection is stable.
-	// Checked on next call to recordShortLivedConnection.
+	self.lastDialSuccess = time.Now()
+	// Don't reset consecutiveFailures yet - wait to see if the connection is stable.
+	// It resets via UnderlayClosed (stable close) or resetStaleFailures (proven lifetime).
 }
 
 func (self *BackoffDialPolicy) recordFailure() {
 	self.mu.Lock()
 	defer self.mu.Unlock()
 	self.consecutiveFailures++
-	self.lastSuccess = time.Time{}
+	self.lastNegativeEvent = time.Now()
 }
 
 // ConsecutiveFailures returns the current consecutive failure count.
@@ -172,7 +200,7 @@ func (self *BackoffDialPolicy) Dial(underlayType string, connectionId string, gr
 	groupId := self.groupConnectionId(connectionId, isFirst)
 	log := pfxlog.Logger().WithField("underlayType", underlayType).WithField("connectionId", groupId).WithField("isFirst", isFirst)
 
-	self.recordStartDial()
+	self.resetStaleFailures()
 
 	if self.Backoff.MinDialInterval > 0 {
 		self.mu.Lock()

--- a/dial_policy.go
+++ b/dial_policy.go
@@ -17,6 +17,7 @@
 package channel
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -25,8 +26,13 @@ import (
 
 // DialPolicy controls how additional underlays are dialed for a multi-underlay channel.
 // The channel passes all necessary context directly, so implementations are self-contained.
+//
+// isFirst is true when the dial is (re)establishing the group's first underlay - either the
+// initial connection or a reconnect after all underlays were lost. A first connection must
+// set the IsFirstGroupConnection header so the remote MultiListener creates a new channel
+// rather than rejecting the underlay; subsequent underlays attach to the existing group.
 type DialPolicy interface {
-	Dial(underlayType string, connectionId string, groupSecret []byte, connectTimeout time.Duration, cancel <-chan struct{}) (Underlay, error)
+	Dial(underlayType string, connectionId string, groupSecret []byte, isFirst bool, connectTimeout time.Duration, cancel <-chan struct{}) (Underlay, error)
 }
 
 // BackoffConfig controls exponential backoff behavior.
@@ -61,6 +67,7 @@ type BackoffDialPolicy struct {
 	consecutiveFailures uint32
 	lastSuccess         time.Time
 	lastDialTime        time.Time
+	iteration           uint32
 }
 
 // NewBackoffDialPolicy creates a BackoffDialPolicy with default configuration.
@@ -140,9 +147,30 @@ func (self *BackoffDialPolicy) LastDialTime() time.Time {
 	return self.lastDialTime
 }
 
+// groupConnectionId returns the wire connection id to use for this dial. On a first connection it
+// advances the iteration counter so the (re)established group gets a distinct id; the initial
+// iteration (0) uses the base id unchanged so it matches the externally dialed first underlay.
+func (self *BackoffDialPolicy) groupConnectionId(connectionId string, isFirst bool) string {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+	if isFirst {
+		self.iteration++
+	}
+	if self.iteration == 0 {
+		return connectionId
+	}
+	return fmt.Sprintf("%s-%d", connectionId, self.iteration)
+}
+
 // Dial attempts to create a new underlay, applying exponential backoff if previous attempts failed.
-func (self *BackoffDialPolicy) Dial(underlayType string, connectionId string, groupSecret []byte, connectTimeout time.Duration, cancel <-chan struct{}) (Underlay, error) {
-	log := pfxlog.Logger().WithField("underlayType", underlayType).WithField("connectionId", connectionId)
+// When isFirst is true the dial (re)establishes the group: it advances the iteration, derives a
+// fresh iteration-suffixed connection id, and sets the IsFirstGroupConnection header so the remote
+// MultiListener creates a new channel. A fresh id avoids attaching to a still-closing channel of
+// the prior iteration during a loss/reconnect race. Subsequent (isFirst == false) dials reuse the
+// current iteration id with no header, so they attach to the established group.
+func (self *BackoffDialPolicy) Dial(underlayType string, connectionId string, groupSecret []byte, isFirst bool, connectTimeout time.Duration, cancel <-chan struct{}) (Underlay, error) {
+	groupId := self.groupConnectionId(connectionId, isFirst)
+	log := pfxlog.Logger().WithField("underlayType", underlayType).WithField("connectionId", groupId).WithField("isFirst", isFirst)
 
 	self.recordStartDial()
 
@@ -180,12 +208,17 @@ func (self *BackoffDialPolicy) Dial(underlayType string, connectionId string, gr
 	default:
 	}
 
-	underlay, err := self.Dialer.CreateWithHeaders(connectTimeout, map[int32][]byte{
+	headers := map[int32][]byte{
 		TypeHeader:         []byte(underlayType),
-		ConnectionIdHeader: []byte(connectionId),
+		ConnectionIdHeader: []byte(groupId),
 		GroupSecretHeader:  groupSecret,
 		IsGroupedHeader:    {1},
-	})
+	}
+	if isFirst {
+		Headers(headers).PutBoolHeader(IsFirstGroupConnection, true)
+	}
+
+	underlay, err := self.Dialer.CreateWithHeaders(connectTimeout, headers)
 	if err != nil {
 		self.recordFailure()
 		log.WithError(err).Info("dial failed")

--- a/dial_policy_test.go
+++ b/dial_policy_test.go
@@ -67,14 +67,14 @@ func Test_BackoffDelay_CappedAtMaxDelay(t *testing.T) {
 	require.Equal(t, time.Second, p.getBackoffDelay())
 }
 
-func Test_RecordFailure_ClearsLastSuccess(t *testing.T) {
+func Test_RecordFailure_RecordsNegativeEvent(t *testing.T) {
 	p := newTestPolicy()
 
 	p.recordSuccess()
-	require.False(t, p.lastSuccess.IsZero())
+	require.False(t, p.lastDialSuccess.IsZero())
 
 	p.recordFailure()
-	require.True(t, p.lastSuccess.IsZero())
+	require.False(t, p.lastNegativeEvent.Before(p.lastDialSuccess))
 	require.Equal(t, uint32(1), p.ConsecutiveFailures())
 }
 
@@ -89,52 +89,53 @@ func Test_RecordSuccess_DoesNotResetFailures(t *testing.T) {
 	require.Equal(t, uint32(2), p.ConsecutiveFailures(), "failures should not reset until connection proves stable")
 }
 
-func Test_RecordStartDial_ShortLivedConnectionCountsAsFailure(t *testing.T) {
+func Test_UnderlayClosed_ShortLivedCountsAsFailure(t *testing.T) {
 	p := newTestPolicy()
 
-	p.recordSuccess()
-	// Call recordStartDial immediately — connection was short-lived
-	p.recordStartDial()
+	p.UnderlayClosed("default", p.Backoff.MinStableDuration/2)
 	require.Equal(t, uint32(1), p.ConsecutiveFailures())
+
+	// repeated short-lived closes escalate
+	p.UnderlayClosed("default", p.Backoff.MinStableDuration/2)
+	require.Equal(t, uint32(2), p.ConsecutiveFailures())
+	require.True(t, p.getBackoffDelay() > 0)
 }
 
-func Test_RecordStartDial_StableConnectionResetsFailures(t *testing.T) {
+func Test_UnderlayClosed_StableLifetimeResetsFailures(t *testing.T) {
 	p := newTestPolicy()
 
-	// Accumulate some failures
 	p.recordFailure()
 	p.recordFailure()
 	p.recordFailure()
 	require.Equal(t, uint32(3), p.ConsecutiveFailures())
 
-	// Simulate a successful connection that lives long enough
-	p.recordSuccess()
-	time.Sleep(p.Backoff.MinStableDuration + 10*time.Millisecond)
-
-	p.recordStartDial()
+	p.UnderlayClosed("default", p.Backoff.MinStableDuration*2)
 	require.Equal(t, uint32(0), p.ConsecutiveFailures())
 	require.Equal(t, time.Duration(0), p.getBackoffDelay())
 }
 
-func Test_RecordStartDial_NoopWithoutPriorSuccess(t *testing.T) {
+func Test_ResetStaleFailures_NoopWithoutPriorSuccess(t *testing.T) {
 	p := newTestPolicy()
 
 	p.recordFailure()
 	p.recordFailure()
 
-	// No success recorded, so recordStartDial should not change failure count
-	p.recordStartDial()
+	// No dial success recorded, so there is no proven-stable connection to reset on.
+	p.resetStaleFailures()
 	require.Equal(t, uint32(2), p.ConsecutiveFailures())
 }
 
-func Test_RecordStartDial_IdempotentOnSecondCall(t *testing.T) {
+func Test_ResetStaleFailures_NoopWhenSuccessPredatesNegativeEvent(t *testing.T) {
 	p := newTestPolicy()
 
+	// A dial succeeded, then that connection died young (UnderlayClosed moved the
+	// negative event past the success). The success proves nothing.
 	p.recordSuccess()
-	p.recordStartDial() // classifies the connection, clears lastSuccess
+	time.Sleep(p.Backoff.MinStableDuration + 10*time.Millisecond)
+	p.UnderlayClosed("default", p.Backoff.MinStableDuration/2)
 	require.Equal(t, uint32(1), p.ConsecutiveFailures())
 
-	p.recordStartDial() // lastSuccess is zero, should be a no-op
+	p.resetStaleFailures()
 	require.Equal(t, uint32(1), p.ConsecutiveFailures())
 }
 
@@ -153,11 +154,11 @@ func Test_FullCycle_FailuresRecoverAfterStableConnection(t *testing.T) {
 	// Failures still elevated — not reset yet
 	require.Equal(t, uint32(3), p.ConsecutiveFailures())
 
-	// Connection lives long enough to be stable
+	// The connection stays up past MinStableDuration without a negative event.
 	time.Sleep(p.Backoff.MinStableDuration + 10*time.Millisecond)
 
-	// Next dial starts: evaluates previous connection as stable, resets failures
-	p.recordStartDial()
+	// Next dial starts: the live connection has proven stable, failures reset
+	p.resetStaleFailures()
 	require.Equal(t, uint32(0), p.ConsecutiveFailures())
 	require.Equal(t, time.Duration(0), p.getBackoffDelay())
 }
@@ -169,17 +170,38 @@ func Test_FullCycle_ShortLivedConnectionEscalatesBackoff(t *testing.T) {
 	p.recordFailure()
 	require.Equal(t, uint32(1), p.ConsecutiveFailures())
 
-	// Second dial succeeds but dies quickly
+	// Second dial succeeds but the underlay dies quickly
 	p.recordSuccess()
-
-	// Next dial starts immediately — short-lived
-	p.recordStartDial()
+	p.UnderlayClosed("default", p.Backoff.MinStableDuration/2)
 	require.Equal(t, uint32(2), p.ConsecutiveFailures())
 
 	// Another success that also dies quickly
 	p.recordSuccess()
-	p.recordStartDial()
+	p.UnderlayClosed("default", p.Backoff.MinStableDuration/2)
 	require.Equal(t, uint32(3), p.ConsecutiveFailures())
+
+	// The young deaths postdate the successes, so nothing resets at dial time.
+	p.resetStaleFailures()
+	require.Equal(t, uint32(3), p.ConsecutiveFailures())
+}
+
+func Test_Dial_ConsecutiveFillDialsDoNotBackoff(t *testing.T) {
+	dialer := &succeedingDialerFactory{}
+	p := NewBackoffDialPolicy(dialer)
+	cancel := make(chan struct{})
+
+	// First underlay (re)establishes the group.
+	_, err := p.Dial("default", "conn-1", []byte("secret"), true, time.Second, cancel)
+	require.NoError(t, err)
+
+	// Additional underlays fill constraints back-to-back (isFirst == false), well within
+	// MinStableDuration. None may be miscounted as short-lived failures or impose backoff.
+	for range 3 {
+		_, err = p.Dial("default", "conn-1", []byte("secret"), false, time.Second, cancel)
+		require.NoError(t, err)
+		require.Equal(t, uint32(0), p.ConsecutiveFailures())
+		require.Equal(t, time.Duration(0), p.getBackoffDelay())
+	}
 }
 
 func Test_Dial_CancelDuringBackoff(t *testing.T) {
@@ -225,7 +247,7 @@ func Test_Dial_FactorySuccessRecordsSuccess(t *testing.T) {
 	underlay, err := p.Dial("default", "conn-1", []byte("secret"), false, time.Second, cancel)
 	require.NoError(t, err)
 	require.NotNil(t, underlay)
-	require.False(t, p.lastSuccess.IsZero())
+	require.False(t, p.lastDialSuccess.IsZero())
 }
 
 func Test_Dial_PassesCorrectHeaders(t *testing.T) {
@@ -305,7 +327,10 @@ type testUnderlay struct {
 	headers      map[int32][]byte
 	connectionId string
 	closed       bool
+	createdAt    time.Time
 }
+
+func (t *testUnderlay) CreatedAt() time.Time { return t.createdAt }
 
 func (t *testUnderlay) Rx() (*Message, error)               { return nil, nil }
 func (t *testUnderlay) Tx(*Message) error                   { return nil }

--- a/dial_policy_test.go
+++ b/dial_policy_test.go
@@ -191,7 +191,7 @@ func Test_Dial_CancelDuringBackoff(t *testing.T) {
 	cancel := make(chan struct{})
 	close(cancel) // already cancelled
 
-	_, err := p.Dial("default", "conn-1", []byte("secret"), time.Second, cancel)
+	_, err := p.Dial("default", "conn-1", []byte("secret"), false, time.Second, cancel)
 	require.Error(t, err)
 	require.IsType(t, ClosedError{}, err)
 }
@@ -202,7 +202,7 @@ func Test_Dial_CancelBeforeDial(t *testing.T) {
 	cancel := make(chan struct{})
 	close(cancel)
 
-	_, err := p.Dial("default", "conn-1", []byte("secret"), time.Second, cancel)
+	_, err := p.Dial("default", "conn-1", []byte("secret"), false, time.Second, cancel)
 	require.Error(t, err)
 	require.IsType(t, ClosedError{}, err)
 }
@@ -212,7 +212,7 @@ func Test_Dial_FactoryFailureRecordsFailure(t *testing.T) {
 	p := NewBackoffDialPolicy(dialer)
 
 	cancel := make(chan struct{})
-	_, err := p.Dial("default", "conn-1", []byte("secret"), time.Second, cancel)
+	_, err := p.Dial("default", "conn-1", []byte("secret"), false, time.Second, cancel)
 	require.Error(t, err)
 	require.Equal(t, uint32(1), p.ConsecutiveFailures())
 }
@@ -222,7 +222,7 @@ func Test_Dial_FactorySuccessRecordsSuccess(t *testing.T) {
 	p := NewBackoffDialPolicy(dialer)
 
 	cancel := make(chan struct{})
-	underlay, err := p.Dial("default", "conn-1", []byte("secret"), time.Second, cancel)
+	underlay, err := p.Dial("default", "conn-1", []byte("secret"), false, time.Second, cancel)
 	require.NoError(t, err)
 	require.NotNil(t, underlay)
 	require.False(t, p.lastSuccess.IsZero())
@@ -233,13 +233,44 @@ func Test_Dial_PassesCorrectHeaders(t *testing.T) {
 	p := NewBackoffDialPolicy(dialer)
 
 	cancel := make(chan struct{})
-	_, err := p.Dial("priority", "conn-42", []byte("mysecret"), time.Second, cancel)
+	_, err := p.Dial("priority", "conn-42", []byte("mysecret"), false, time.Second, cancel)
 	require.NoError(t, err)
 
 	require.Equal(t, "priority", string(dialer.lastHeaders[TypeHeader]))
 	require.Equal(t, "conn-42", string(dialer.lastHeaders[ConnectionIdHeader]))
 	require.Equal(t, []byte("mysecret"), dialer.lastHeaders[GroupSecretHeader])
 	require.Equal(t, []byte{1}, dialer.lastHeaders[IsGroupedHeader])
+
+	// a non-first dial does not mark itself as a first group connection
+	_, found := Headers(dialer.lastHeaders).GetBoolHeader(IsFirstGroupConnection)
+	require.False(t, found)
+}
+
+func Test_Dial_FirstConnectionSetsHeaderAndIteratesId(t *testing.T) {
+	dialer := &succeedingDialerFactory{}
+	p := NewBackoffDialPolicy(dialer)
+
+	cancel := make(chan struct{})
+
+	// first connection: header set, id carries the iteration suffix
+	_, err := p.Dial("default", "conn-7", []byte("secret"), true, time.Second, cancel)
+	require.NoError(t, err)
+	require.Equal(t, "conn-7-1", string(dialer.lastHeaders[ConnectionIdHeader]))
+	isFirst, found := Headers(dialer.lastHeaders).GetBoolHeader(IsFirstGroupConnection)
+	require.True(t, found)
+	require.True(t, isFirst)
+
+	// additional underlay in the same iteration: same id, no first-connection header
+	_, err = p.Dial("default", "conn-7", []byte("secret"), false, time.Second, cancel)
+	require.NoError(t, err)
+	require.Equal(t, "conn-7-1", string(dialer.lastHeaders[ConnectionIdHeader]))
+	_, found = Headers(dialer.lastHeaders).GetBoolHeader(IsFirstGroupConnection)
+	require.False(t, found)
+
+	// reconnect after full loss: a new iteration produces a fresh id
+	_, err = p.Dial("default", "conn-7", []byte("secret"), true, time.Second, cancel)
+	require.NoError(t, err)
+	require.Equal(t, "conn-7-2", string(dialer.lastHeaders[ConnectionIdHeader]))
 }
 
 // failingDialerFactory is a DialUnderlayFactory that always returns an error.

--- a/existing_conn_impl.go
+++ b/existing_conn_impl.go
@@ -37,6 +37,11 @@ type existingConnImpl struct {
 	closed       atomic.Bool
 	readF        readFunction
 	marshalF     marshalFunction
+	createdAt    time.Time
+}
+
+func (impl *existingConnImpl) CreatedAt() time.Time {
+	return impl.createdAt
 }
 
 func (impl *existingConnImpl) GetLocalAddr() net.Addr {
@@ -139,8 +144,9 @@ func newExistingImpl(peer net.Conn, version uint32) *existingConnImpl {
 	}
 
 	return &existingConnImpl{
-		peer:     peer,
-		readF:    readF,
-		marshalF: marshalF,
+		peer:      peer,
+		readF:     readF,
+		marshalF:  marshalF,
+		createdAt: time.Now(),
 	}
 }

--- a/impl.go
+++ b/impl.go
@@ -826,7 +826,12 @@ func (self *channelImpl) dialUnderlay(underlayType string) {
 		connectTimeout = self.options.ConnectTimeout
 	}
 
-	underlay, err := self.dialPolicy.Dial(underlayType, self.channelId, self.groupSecret, connectTimeout, self.closeNotify)
+	// isFirst is true when no underlays remain, i.e. this dial re-establishes the group after
+	// full loss. The initial underlay is supplied to NewChannel rather than dialed here, so a
+	// first-connection dial only occurs on reconnect.
+	isFirst := len(self.underlays.GetAll()) == 0
+
+	underlay, err := self.dialPolicy.Dial(underlayType, self.channelId, self.groupSecret, isFirst, connectTimeout, self.closeNotify)
 	if err != nil {
 		if self.IsClosed() {
 			log.Debug("dial cancelled, channel closed")

--- a/impl.go
+++ b/impl.go
@@ -676,13 +676,21 @@ func (self *channelImpl) UnderlayAdded(ch Channel, underlay Underlay) {
 		Info("underlay added")
 }
 
-// UnderlayRemoved implements UnderlayEventListener. Checks constraints and triggers re-dial if needed.
+// UnderlayRemoved implements UnderlayEventListener. Reports the underlay's lifetime to the
+// dial policy for stability accounting, then checks constraints and triggers re-dial if needed.
 func (self *channelImpl) UnderlayRemoved(ch Channel, underlay Underlay) {
+	lifetime := time.Since(underlay.CreatedAt())
+
 	pfxlog.Logger().
 		WithField("id", ch.Label()).
 		WithField("underlays", ch.GetUnderlayCountsByType()).
 		WithField("underlayType", GetUnderlayType(underlay)).
+		WithField("lifetime", lifetime).
 		Info("underlay removed")
+
+	if self.dialPolicy != nil {
+		self.dialPolicy.UnderlayClosed(self.getValidatedUnderlayType(underlay), lifetime)
+	}
 
 	if len(self.constraints) == 0 && self.dialPolicy == nil {
 		// No constraints or dial policy means this is a simple channel that cannot

--- a/memory/impl.go
+++ b/memory/impl.go
@@ -20,13 +20,14 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"github.com/michaelquigley/pfxlog"
-	"github.com/openziti/channel/v5"
-	"github.com/openziti/identity"
 	"io"
 	"net"
 	"sync"
 	"time"
+
+	"github.com/michaelquigley/pfxlog"
+	"github.com/openziti/channel/v5"
+	"github.com/openziti/identity"
 )
 
 type addr string
@@ -47,6 +48,11 @@ type memoryImpl struct {
 	headers      map[int32][]byte
 	closeLock    sync.Mutex
 	closed       bool
+	createdAt    time.Time
+}
+
+func (self *memoryImpl) CreatedAt() time.Time {
+	return self.createdAt
 }
 
 func (self *memoryImpl) GetLocalAddr() net.Addr {
@@ -134,8 +140,9 @@ func (self *memoryImpl) IsClosed() bool {
 
 func newMemoryImpl(tx, rx chan *channel.Message) *memoryImpl {
 	return &memoryImpl{
-		tx: tx,
-		rx: rx,
+		tx:        tx,
+		rx:        rx,
+		createdAt: time.Now(),
 	}
 }
 

--- a/reconnecting_impl.go
+++ b/reconnecting_impl.go
@@ -19,15 +19,16 @@ package channel
 import (
 	"crypto/x509"
 	"fmt"
+	"io"
+	"net"
+	"sync/atomic"
+	"time"
+
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/foundation/v2/concurrenz"
 	"github.com/openziti/identity"
 	"github.com/openziti/transport/v2"
 	"github.com/pkg/errors"
-	"io"
-	"net"
-	"sync/atomic"
-	"time"
 )
 
 func (impl *reconnectingImpl) Rx() (*Message, error) {
@@ -134,6 +135,7 @@ func newReconnectingImpl(peer transport.Conn, reconnectionHandler reconnectionHa
 		readF:               ReadV2,
 		marshalF:            MarshalV2,
 		timeout:             timeout,
+		createdAt:           time.Now(),
 	}
 }
 
@@ -228,6 +230,13 @@ type reconnectingImpl struct {
 	disconnected        atomic.Bool
 	reconnecting        atomic.Bool
 	timeout             time.Duration
+	createdAt           time.Time
+}
+
+// CreatedAt returns the time the underlay was originally created. It is not updated
+// when the underlay internally reconnects.
+func (impl *reconnectingImpl) CreatedAt() time.Time {
+	return impl.createdAt
 }
 
 func (impl *reconnectingImpl) GetLocalAddr() net.Addr {

--- a/type_logging_underlay.go
+++ b/type_logging_underlay.go
@@ -18,9 +18,10 @@ package channel
 
 import (
 	"crypto/x509"
-	"github.com/michaelquigley/pfxlog"
 	"net"
 	"time"
+
+	"github.com/michaelquigley/pfxlog"
 )
 
 // TypeLoggingUnderlay wraps an Underlay and logs the content type of each transmitted message.
@@ -83,4 +84,8 @@ func (self *TypeLoggingUnderlay) GetLocalAddr() net.Addr {
 
 func (self *TypeLoggingUnderlay) GetRemoteAddr() net.Addr {
 	return self.wrapped.GetRemoteAddr()
+}
+
+func (self *TypeLoggingUnderlay) CreatedAt() time.Time {
+	return self.wrapped.CreatedAt()
 }

--- a/websockets/ws_underlay.go
+++ b/websockets/ws_underlay.go
@@ -19,28 +19,35 @@ package websockets
 import (
 	"bytes"
 	"crypto/x509"
+	"net"
+	"sync/atomic"
+	"time"
+
 	"github.com/gorilla/websocket"
 	"github.com/openziti/channel/v5"
 	"github.com/openziti/identity"
 	"github.com/pkg/errors"
-	"net"
-	"sync/atomic"
-	"time"
 )
 
 type Underlay struct {
-	id     *identity.TokenId
-	peer   *websocket.Conn
-	closed atomic.Bool
-	certs  []*x509.Certificate
+	id        *identity.TokenId
+	peer      *websocket.Conn
+	closed    atomic.Bool
+	certs     []*x509.Certificate
+	createdAt time.Time
 }
 
 func NewUnderlayFactory(id *identity.TokenId, peer *websocket.Conn, certs []*x509.Certificate) channel.UnderlayFactory {
 	return &Underlay{
-		id:    id,
-		peer:  peer,
-		certs: certs,
+		id:        id,
+		peer:      peer,
+		certs:     certs,
+		createdAt: time.Now(),
 	}
+}
+
+func (self *Underlay) CreatedAt() time.Time {
+	return self.createdAt
 }
 
 func (self *Underlay) GetLocalAddr() net.Addr {

--- a/ws_impl.go
+++ b/ws_impl.go
@@ -20,10 +20,11 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"github.com/openziti/identity"
-	"github.com/openziti/transport/v2"
 	"sync"
 	"time"
+
+	"github.com/openziti/identity"
+	"github.com/openziti/transport/v2"
 )
 
 type wsImpl struct {
@@ -35,6 +36,11 @@ type wsImpl struct {
 	closed       bool
 	readF        readFunction
 	marshalF     marshalFunction
+	createdAt    time.Time
+}
+
+func (self *wsImpl) CreatedAt() time.Time {
+	return self.createdAt
 }
 
 func (self *wsImpl) SetWriteTimeout(duration time.Duration) error {
@@ -123,8 +129,9 @@ func newWSImpl(peer transport.Conn, version uint32) *wsImpl {
 	}
 
 	return &wsImpl{
-		peer:     peer,
-		readF:    readF,
-		marshalF: marshalF,
+		peer:      peer,
+		readF:     readF,
+		marshalF:  marshalF,
+		createdAt: time.Now(),
 	}
 }


### PR DESCRIPTION
Fixes #250
Fixes #252

This PR has two related commits on `DialPolicy`/`BackoffDialPolicy`.

## 1. First-connection support (#250)

`BackoffDialPolicy` never set `IsFirstGroupConnection`. A `MultiListener` only creates a channel for a grouped underlay when that header is set; otherwise, with no existing channel for the connection id, it closes the underlay. So the policy could only *add* an underlay to an already-established group - it could not establish the first underlay or recover a channel configured to survive full underlay loss and re-dial.

- Added `isFirst bool` to `DialPolicy.Dial`. `channelImpl.dialUnderlay` computes it as "no underlays remain", which only occurs on reconnect after full loss (the initial underlay is supplied to `NewChannel`, not dialed through the policy).
- `BackoffDialPolicy` sets `IsFirstGroupConnection=true` on a first connection and derives a fresh iteration-suffixed connection id (`<id>-<n>`), so a reconnect creates a new channel rather than racing a still-closing prior iteration. `AcceptUnderlay` validates by group secret, not connection id, so the iterated wire id is safe for the local channel.

## 2. Don't count constraint fill as short-lived (#252)

`BackoffDialPolicy`'s short-lived/flap detection treated any dial starting within `MinStableDuration` of the last success as a short-lived failure. When a multi-underlay channel fills more than one underlay, `applyConstraints` dials them back-to-back, so healthy fill dials were miscounted as flaps and penalized with exponential backoff.

- Gated short-lived detection on `isFirst`: only a reconnect-from-zero can be short-lived; a non-first (constraint-fill) dial treats a recent success as proof of health and resets the failure count.

## Compatibility / notes

- Breaking change to the `DialPolicy` interface (added `isFirst`), but `BackoffDialPolicy` is the only implementer today, so it is cheapest to make now.
- `isFirst` is derived purely from "zero underlays remain", correct given the initial underlay is never dialed via the policy.

## Verification

- `go build ./...`, `go vet .`, full `go test .`.
- Tests: first-connection header + id iteration, same-iteration reuse, reconnect iteration; consecutive successful fill dials keep `ConsecutiveFailures` at zero with no backoff; flap-detection tests confirm the isFirst path still escalates.