### PR TITLE
Check min-validity before the constraint in-progress guard

### DIFF
--- a/impl.go
+++ b/impl.go
@@ -703,6 +703,19 @@ func (self *channelImpl) applyConstraints() {
 		return
 	}
 
+	if self.IsClosed() {
+		return
+	}
+
+	// Check min-validity (and close if below minimum) BEFORE taking the in-progress
+	// guard. A required-underlay loss must close the channel promptly even when another
+	// constraint fill or dial backoff is already running; otherwise the close would be
+	// deferred until that in-progress dial returns (up to the full backoff delay).
+	// Closing here also cancels any in-flight dial, since it closes closeNotify.
+	if !self.checkConstraintsValid(true) {
+		return
+	}
+
 	if !self.applyInProgress.CompareAndSwap(false, true) {
 		return
 	}
@@ -720,14 +733,6 @@ func (self *channelImpl) applyConstraints() {
 			go self.applyConstraints()
 		}
 	}()
-
-	if self.IsClosed() {
-		return
-	}
-
-	if !self.checkConstraintsValid(true) {
-		return
-	}
 
 	if self.dialPolicy == nil {
 		return

--- a/underlays_test.go
+++ b/underlays_test.go
@@ -186,3 +186,28 @@ func (l *testUnderlayListenerF) UnderlayRemoved(ch Channel, u Underlay) {
 		l.onRemoved(ch, u)
 	}
 }
+
+// Test_applyConstraints_ClosesBelowMinEvenWhenApplyInProgress is the regression test for the
+// ordering bug where applyConstraints took the in-progress guard before checking min-validity.
+// A required-underlay loss must close the channel promptly even when another constraint
+// fill / dial backoff is already running, rather than waiting for that dial to return.
+func Test_applyConstraints_ClosesBelowMinEvenWhenApplyInProgress(t *testing.T) {
+	impl := &channelImpl{
+		constraints: map[string]UnderlayConstraint{"default": {Desired: 1, Min: 1}},
+		underlays:   NewUnderlays(),
+		closeNotify: make(chan struct{}),
+	}
+	// fallbackUnderlay backs Label()/Underlay(), used by the close-path logging.
+	var u Underlay = &testUnderlay{}
+	impl.fallbackUnderlay.Store(&u)
+
+	// Simulate an applyConstraints run already in progress (e.g. a dial backing off).
+	impl.applyInProgress.Store(true)
+
+	// No underlays remain, so the channel is below the default Min of 1. The min-validity
+	// close check runs before the in-progress guard, so the channel closes immediately
+	// rather than waiting for the in-progress dial.
+	impl.applyConstraints()
+
+	require.True(t, impl.IsClosed(), "channel below min must close even while applyInProgress is held")
+}


### PR DESCRIPTION
Fixes #253

## Problem

`channelImpl.applyConstraints()` took the `applyInProgress` guard before checking minimum-underlay validity. `dialUnderlay` runs inside the constraint loop and `DialPolicy.Dial` sleeps during `MinDialInterval`/backoff, so `applyInProgress` stays set for the duration of a dial. If a required underlay (`Min >= 1`) was removed during that window, the `UnderlayRemoved -> go applyConstraints()` call bailed at the `CompareAndSwap` and never reached the close check, leaving the channel open below its minimum until the in-progress dial returned (up to the full backoff delay).

For consumers with a required data-path underlay (ziti xlink and edge SDK use `Min: 1` on the default underlay) this delays failover over a dead path. It is a regression from the prior `UnderlayConstraints.Apply`, which checked validity before the guard.

## Change

Run the min-validity close check (`IsClosed` + `checkConstraintsValid(true)`) before taking the in-progress guard. The guard now only protects the dialing loop. Closing on the check also closes `closeNotify`, which the in-flight `DialPolicy.Dial` selects on, so the close also cancels a backing-off dial.

## Verification

- `go build ./...`, `go vet .`, full `go test .`.
- New `Test_applyConstraints_ClosesBelowMinEvenWhenApplyInProgress`: with `applyInProgress` held and no underlays, a `Min: 1` channel closes immediately (fails on the old ordering, which bailed at the guard).