### PR TITLE
Make CloseRandom minimum-aware to fix flaky Test_MultiUnderlayChannels

### DIFF
--- a/multi_test.go
+++ b/multi_test.go
@@ -239,10 +239,25 @@ func (self *priorityChannelBase) CloseRandom(ch Channel) {
 	mc.lock.Lock()
 	defer mc.lock.Unlock()
 	underlays := mc.underlays.GetAll()
-	if len(underlays) > 0 {
-		idx := rand.Intn(len(underlays))
-		underlay := underlays[idx]
-		_ = underlay.Close()
+
+	// Only close an underlay whose type would still meet its required Min afterwards.
+	// Closing the last required underlay (e.g. default, Min: 1) would drop the channel
+	// below minimum and close it; that is not what this churn test exercises, and it
+	// raced with the random close interval, making the test flaky.
+	counts := map[string]int{}
+	for _, u := range underlays {
+		counts[GetUnderlayType(u)]++
+	}
+	var closeable []Underlay
+	for _, u := range underlays {
+		t := GetUnderlayType(u)
+		if counts[t]-1 < mc.constraints[t].Min {
+			continue
+		}
+		closeable = append(closeable, u)
+	}
+	if len(closeable) > 0 {
+		_ = closeable[rand.Intn(len(closeable))].Close()
 	}
 }
 


### PR DESCRIPTION
Fixes #255

## Problem

`Test_MultiUnderlayChannels` intermittently fails in CI (passes on re-run): the test's `CloseRandom` closes a uniformly random underlay every second while sending 3000 messages on the default sender. With `default {Desired: 2, Min: 1}`, closing the last `default` underlay (while the second is mid-re-dial) drops the channel below `Min`, closes it, and fails the in-flight send. Timing-dependent, so it shows up on slow CI runners more than locally.

Reproduced deterministically by closing several underlays per tick on a fast ticker (forces `default` -> 0 every run, matching the CI log signature).

## Change

`CloseRandom` is now minimum-aware: it only closes an underlay whose type would still satisfy its constraint `Min` after removal (reading the channel's own `constraints`). This keeps the test's intent - churn underlays and verify delivery keeps working while re-dial refills them, including churning a `default` underlay when two are present - but never closes the last required underlay, so the channel never self-closes below minimum. `priority {Min: 0}` underlays remain freely churned.

Note: this relies on closes being spaced enough for a closed underlay's removal to propagate before the next close (true at the test's 1s cadence); rapid-fire closing within the propagation window would read stale counts, which is not a realistic scenario for this test.

## Verification

- Deterministic root-cause repro fails before the change.
- With the fix: 10/10 under heavy single-close churn (15ms interval) and passes at the normal 1s cadence; full `go test .` green.