### PR TITLE
Close underlay on all hello-handshake failures (FD leak)

### DIFF
--- a/classic_dialer.go
+++ b/classic_dialer.go
@@ -107,20 +107,29 @@ func (self *classicDialer) CreateWithHeaders(timeout time.Duration, headers map[
 	return nil, errors.New("timeout waiting for dial")
 }
 
-func (self *classicDialer) sendHello(underlay classicUnderlay, deadline time.Time, headers map[int32][]byte) error {
+func (self *classicDialer) sendHello(underlay classicUnderlay, deadline time.Time, headers map[int32][]byte) (err error) {
 	log := pfxlog.ContextLogger(underlay.Label())
 	defer log.Debug("exited")
 	log.Debug("started")
 
+	// Close the underlay (and its transport FD) on any hello failure. Only a fully
+	// successful handshake returns the underlay to the caller; every other path used to
+	// return without closing, leaking the connection.
+	defer func() {
+		if err != nil {
+			_ = underlay.Close()
+		}
+	}()
+
 	peer := underlay.getPeer()
 
-	if err := peer.SetDeadline(deadline); err != nil {
+	if err = peer.SetDeadline(deadline); err != nil {
 		return err
 	}
 
 	defer func() {
-		if err := peer.SetDeadline(time.Time{}); err != nil { // clear write deadline
-			log.WithError(err).Error("unable to clear deadline")
+		if dlErr := peer.SetDeadline(time.Time{}); dlErr != nil { // clear write deadline
+			log.WithError(dlErr).Error("unable to clear deadline")
 		}
 	}()
 
@@ -129,12 +138,12 @@ func (self *classicDialer) sendHello(underlay classicUnderlay, deadline time.Tim
 		request.Headers[k] = v
 	}
 	request.SetSequence(HelloSequence)
-	if err := underlay.Tx(request); err != nil {
-		_ = underlay.Close()
+	if err = underlay.Tx(request); err != nil {
 		return err
 	}
 
-	response, err := underlay.Rx()
+	var response *Message
+	response, err = underlay.Rx()
 	if err != nil {
 		if errors.Is(err, BadMagicNumberError) {
 			return fmt.Errorf("could not negotiate connection with %v, invalid header", peer.RemoteAddr().String())

--- a/classic_dialer_test.go
+++ b/classic_dialer_test.go
@@ -1,0 +1,86 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package channel
+
+import (
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/openziti/identity"
+	"github.com/openziti/transport/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeHelloPeer is a minimal transport.Conn for sendHello: it only needs the deadline
+// and remote-address calls the handshake makes.
+type fakeHelloPeer struct {
+	transport.Conn
+}
+
+func (fakeHelloPeer) SetDeadline(time.Time) error { return nil }
+func (fakeHelloPeer) RemoteAddr() net.Addr        { return &net.TCPAddr{} }
+
+// fakeHelloUnderlay is a minimal classicUnderlay for sendHello. It embeds Underlay so the
+// type is satisfied; only the methods the handshake touches are implemented. Tx/Rx outcomes
+// are configurable so each hello-failure path can be exercised.
+type fakeHelloUnderlay struct {
+	Underlay
+	txErr  error
+	rxErr  error
+	closed bool
+}
+
+func (f *fakeHelloUnderlay) Label() string                { return "fake" }
+func (f *fakeHelloUnderlay) getPeer() transport.Conn      { return fakeHelloPeer{} }
+func (f *fakeHelloUnderlay) init(string, string, Headers) {}
+func (f *fakeHelloUnderlay) rxHello() (*Message, error)   { return nil, nil }
+func (f *fakeHelloUnderlay) Tx(*Message) error            { return f.txErr }
+func (f *fakeHelloUnderlay) Rx() (*Message, error)        { return nil, f.rxErr }
+func (f *fakeHelloUnderlay) Close() error                 { f.closed = true; return nil }
+
+// Test_sendHello_ClosesUnderlayOnFailure is the regression test for the FD leak in #246:
+// every hello-handshake failure must close the underlay (and its transport connection),
+// not just the Tx-error path.
+func Test_sendHello_ClosesUnderlayOnFailure(t *testing.T) {
+	dialer := &classicDialer{
+		identity: &identity.TokenId{Token: "test"},
+		headers:  map[int32][]byte{},
+	}
+
+	t.Run("Tx failure closes underlay", func(t *testing.T) {
+		u := &fakeHelloUnderlay{txErr: errors.New("tx boom")}
+		err := dialer.sendHello(u, time.Now().Add(time.Second), nil)
+		require.Error(t, err)
+		require.True(t, u.closed, "underlay must be closed when Tx fails")
+	})
+
+	t.Run("Rx failure closes underlay", func(t *testing.T) {
+		u := &fakeHelloUnderlay{rxErr: errors.New("rx boom")}
+		err := dialer.sendHello(u, time.Now().Add(time.Second), nil)
+		require.Error(t, err)
+		require.True(t, u.closed, "underlay must be closed when Rx fails (was the leaking path)")
+	})
+
+	t.Run("BadMagicNumber failure closes underlay", func(t *testing.T) {
+		u := &fakeHelloUnderlay{rxErr: BadMagicNumberError}
+		err := dialer.sendHello(u, time.Now().Add(time.Second), nil)
+		require.Error(t, err)
+		require.True(t, u.closed, "underlay must be closed on invalid-header response")
+	})
+}


### PR DESCRIPTION
Fixes #246

## Problem

`classicDialer.sendHello` leaked the underlying transport connection (and its file descriptor) on every hello-handshake failure path except `Tx` errors. `Rx` errors, `BadMagicNumberError`, an unexpected reply, and an unsuccessful result all returned without calling `underlay.Close()`, and `CreateWithHeaders` then discarded the underlay (on both its retry `continue` and its `return`), so the TCP+TLS connection stayed open until process exit.

## Change

`sendHello` now closes the underlay on any error, via a single deferred guard on the named return value. Only a fully successful handshake leaves `err == nil` and returns the underlay to the caller for use. The previous one-off `Close()` on the `Tx` path is removed as redundant (single owner of the close). `CreateWithHeaders` needs no change: the only underlays it discards are ones `sendHello` failed on, which are now already closed.

This also covers the early `peer.SetDeadline` error path, which previously returned without closing too.

## Verification

- New `Test_sendHello_ClosesUnderlayOnFailure` asserts the underlay is closed on the Tx, Rx, and BadMagicNumber failure paths (the Rx path is the one the issue called out).
- `go build ./...`, `go vet .`, full `go test .` green.