### PR TITLE
Add HelloHeaderProvider hook to the classic dialer

### DIFF
--- a/classic_dialer.go
+++ b/classic_dialer.go
@@ -17,22 +17,61 @@
 package channel
 
 import (
+	"crypto/x509"
 	"errors"
 	"fmt"
+	"maps"
+	"time"
+
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/identity"
 	"github.com/openziti/transport/v2"
-	"time"
 )
 
+// HelloHeaderProvider adjusts the hello headers based on the peer's certificates. It is
+// invoked after the transport connection is established (so the peer's certificates are
+// available) but before the hello is sent, letting a dialer set hello headers that depend on
+// the peer's verified identity. headers contains the headers already set on the hello
+// (statically-configured and per-dial); the provider may add, modify or remove entries
+// directly. Entries should be replaced rather than having their value slices edited in place,
+// as values may be shared with the dialer's configuration. Returning an error aborts the dial,
+// and that error is treated as non-retryable: the dialer does not open another connection to
+// retry, since a provider that returns an error has made a deliberate decision about this
+// specific peer.
+type HelloHeaderProvider func(peerCertificates []*x509.Certificate, headers map[int32][]byte) error
+
+// NonRetryableError marks an error as a deliberate, final dial failure that the dialer must not
+// retry internally (in contrast to a protocol-version negotiation error, which is retried).
+type NonRetryableError struct {
+	err error
+}
+
+func (self *NonRetryableError) Error() string {
+	if self.err == nil {
+		return "non-retryable dial failure"
+	}
+	return self.err.Error()
+}
+
+func (self *NonRetryableError) Unwrap() error {
+	return self.err
+}
+
+// IsNonRetryable reports whether err (or any error it wraps) is a NonRetryableError.
+func IsNonRetryable(err error) bool {
+	var nonRetryable *NonRetryableError
+	return errors.As(err, &nonRetryable)
+}
+
 type classicDialer struct {
-	identity        *identity.TokenId
-	endpoint        transport.Address
-	localBinding    string
-	headers         map[int32][]byte
-	underlayFactory func(messageStrategy MessageStrategy, peer transport.Conn, version uint32) classicUnderlay
-	messageStrategy MessageStrategy
-	transportConfig transport.Configuration
+	identity            *identity.TokenId
+	endpoint            transport.Address
+	localBinding        string
+	headers             map[int32][]byte
+	underlayFactory     func(messageStrategy MessageStrategy, peer transport.Conn, version uint32) classicUnderlay
+	messageStrategy     MessageStrategy
+	transportConfig     transport.Configuration
+	helloHeaderProvider HelloHeaderProvider
 }
 
 // DialerConfig holds configuration for creating a classic dialer.
@@ -43,17 +82,21 @@ type DialerConfig struct {
 	Headers         map[int32][]byte
 	MessageStrategy MessageStrategy
 	TransportConfig transport.Configuration
+	// HelloHeaderProvider, if set, is invoked after the transport connection is established and
+	// before the hello is sent, to compute additional hello headers from the peer's certificates.
+	HelloHeaderProvider HelloHeaderProvider
 }
 
 // NewClassicDialer creates a DialUnderlayFactory that dials using the classic transport protocol.
 func NewClassicDialer(cfg DialerConfig) DialUnderlayFactory {
 	result := &classicDialer{
-		identity:        cfg.Identity,
-		endpoint:        cfg.Endpoint,
-		localBinding:    cfg.LocalBinding,
-		headers:         cfg.Headers,
-		messageStrategy: cfg.MessageStrategy,
-		transportConfig: cfg.TransportConfig,
+		identity:            cfg.Identity,
+		endpoint:            cfg.Endpoint,
+		localBinding:        cfg.LocalBinding,
+		headers:             cfg.Headers,
+		messageStrategy:     cfg.MessageStrategy,
+		transportConfig:     cfg.TransportConfig,
+		helloHeaderProvider: cfg.HelloHeaderProvider,
 	}
 
 	if cfg.Endpoint.Type() == "dtls" {
@@ -92,7 +135,7 @@ func (self *classicDialer) CreateWithHeaders(timeout time.Duration, headers map[
 
 		underlay := self.underlayFactory(self.messageStrategy, peer, version)
 		if err = self.sendHello(underlay, deadline, headers); err != nil {
-			if tryCount > 0 {
+			if tryCount > 0 || IsNonRetryable(err) {
 				return nil, err
 			} else {
 				log.WithError(err).Warnf("error initiating channel with hello")
@@ -134,9 +177,18 @@ func (self *classicDialer) sendHello(underlay classicUnderlay, deadline time.Tim
 	}()
 
 	request := NewHello(self.identity.Token, self.headers)
-	for k, v := range headers {
-		request.Headers[k] = v
+	maps.Copy(request.Headers, headers)
+
+	// Let the caller adjust the hello headers based on the peer's (now-available)
+	// certificates, e.g. to set headers that depend on the verified identity of the
+	// peer we reached. The provider mutates the hello's headers directly.
+	if self.helloHeaderProvider != nil {
+		if err := self.helloHeaderProvider(peer.PeerCertificates(), request.Headers); err != nil {
+			_ = underlay.Close()
+			return &NonRetryableError{err: err}
+		}
 	}
+
 	request.SetSequence(HelloSequence)
 	if err = underlay.Tx(request); err != nil {
 		return err
@@ -158,7 +210,10 @@ func (self *classicDialer) sendHello(underlay classicUnderlay, deadline time.Tim
 		return errors.New(result.Message)
 	}
 
-	connectionId := string(headers[ConnectionIdHeader])
+	// Use request.Headers (which includes any headers contributed by the HelloHeaderProvider)
+	// rather than the pre-provider headers argument, so a provider-set ConnectionId drives the
+	// local underlay's grouping as well as the outbound hello.
+	connectionId := string(request.Headers[ConnectionIdHeader])
 	if connectionId == "" {
 		connectionId = string(response.Headers[ConnectionIdHeader])
 	}
@@ -170,9 +225,10 @@ func (self *classicDialer) sendHello(underlay classicUnderlay, deadline time.Tim
 		id = certs[0].Subject.CommonName
 	}
 
-	// type should always be controller by the dialing side, the listener shouldn't be setting a type
-	// in the header. Set the type here, so we can know the type on the dialing side as well
-	response.Headers[TypeHeader] = headers[TypeHeader]
+	// the type is set by the dialing side, not the listener. Use request.Headers (which includes any
+	// headers contributed by the HelloHeaderProvider) rather than the pre-provider headers argument,
+	// so a provider-set type drives the local underlay as well as the outbound hello.
+	response.Headers[TypeHeader] = request.Headers[TypeHeader]
 	underlay.init(id, connectionId, response.Headers)
 
 	return nil

--- a/hello_header_provider_test.go
+++ b/hello_header_provider_test.go
@@ -1,0 +1,273 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package channel
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openziti/identity"
+	"github.com/openziti/transport/v2"
+	"github.com/openziti/transport/v2/tcp"
+	transporttls "github.com/openziti/transport/v2/tls"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	helloHeaderProviderTestHeader = 19876
+	helloHeaderProviderBaseHeader = 19877
+)
+
+// Test_HelloHeaderProvider_HeadersReachListener verifies that headers set by a
+// HelloHeaderProvider reach the listener via the hello, and that the provider receives
+// the current hello headers (statically-configured and per-dial) so it can derive new
+// values from existing ones.
+func Test_HelloHeaderProvider_HeadersReachListener(t *testing.T) {
+	transport.AddAddressParser(tcp.AddressParser{})
+	req := require.New(t)
+
+	listenAddr, err := transport.ParseAddress("tcp:0.0.0.0:6768")
+	req.NoError(err)
+	dialAddr, err := transport.ParseAddress("tcp:127.0.0.1:6768")
+	req.NoError(err)
+
+	receivedHeaders := make(chan map[int32][]byte, 1)
+	acceptF := func(underlay Underlay) {
+		select {
+		case receivedHeaders <- underlay.Headers():
+		default:
+		}
+	}
+
+	listener, err := NewClassicListenerF(&identity.TokenId{Token: "test-server"}, listenAddr,
+		ListenerConfig{ConnectOptions: DefaultConnectOptions()}, acceptF)
+	req.NoError(err)
+	defer func() { _ = listener.Close() }()
+
+	var providerCalled atomic.Bool
+	const providerConnId = "provider-conn-id"
+	const providerType = "provider-type"
+	const dialConnId = "dial-conn-id"
+	dialer := NewClassicDialer(DialerConfig{
+		Identity: &identity.TokenId{Token: "test-client"},
+		Endpoint: dialAddr,
+		Headers: map[int32][]byte{
+			helloHeaderProviderBaseHeader: []byte("base"),
+		},
+		HelloHeaderProvider: func(peerCertificates []*x509.Certificate, headers map[int32][]byte) error {
+			providerCalled.Store(true)
+
+			// the provider sees both statically-configured and per-dial headers
+			if string(headers[helloHeaderProviderBaseHeader]) != "base" {
+				return errors.New("statically-configured header not visible to provider")
+			}
+			if string(headers[ConnectionIdHeader]) != dialConnId {
+				return errors.New("per-dial header not visible to provider")
+			}
+
+			// derive a new value from an existing header
+			headers[helloHeaderProviderBaseHeader] = []byte(string(headers[helloHeaderProviderBaseHeader]) + "+appended")
+			headers[helloHeaderProviderTestHeader] = []byte("injected")
+			headers[ConnectionIdHeader] = []byte(providerConnId)
+			headers[TypeHeader] = []byte(providerType)
+			return nil
+		},
+	})
+
+	underlay, err := dialer.CreateWithHeaders(2*time.Second, map[int32][]byte{
+		ConnectionIdHeader: []byte(dialConnId),
+	})
+	req.NoError(err)
+	defer func() { _ = underlay.Close() }()
+
+	req.True(providerCalled.Load(), "HelloHeaderProvider should be invoked during the dial")
+	req.Equal(providerConnId, underlay.ConnectionId(),
+		"a provider-set ConnectionId should drive the local underlay's grouping, not just the hello")
+	req.Equal(providerType, GetUnderlayType(underlay),
+		"a provider-set type should drive the local underlay's type, not just the hello")
+
+	select {
+	case h := <-receivedHeaders:
+		req.Equal([]byte("injected"), h[helloHeaderProviderTestHeader],
+			"header injected by the provider should reach the listener via the hello")
+		req.Equal([]byte("base+appended"), h[helloHeaderProviderBaseHeader],
+			"a provider-modified header derived from an existing one should reach the listener")
+	case <-time.After(2 * time.Second):
+		req.Fail("listener did not receive an underlay")
+	}
+}
+
+// Test_HelloHeaderProvider_PeerCertificatesOverTls verifies that the provider is invoked with
+// the peer's verified certificates when dialing over TLS, and that a header derived from those
+// certificates reaches the listener.
+func Test_HelloHeaderProvider_PeerCertificatesOverTls(t *testing.T) {
+	transport.AddAddressParser(transporttls.AddressParser{})
+	req := require.New(t)
+
+	serverId, clientId := newTestTlsIdentities(req)
+
+	listenAddr, err := transport.ParseAddress("tls:0.0.0.0:6770")
+	req.NoError(err)
+	dialAddr, err := transport.ParseAddress("tls:127.0.0.1:6770")
+	req.NoError(err)
+
+	type acceptResult struct {
+		headers map[int32][]byte
+		certs   []*x509.Certificate
+	}
+	accepted := make(chan acceptResult, 1)
+	acceptF := func(underlay Underlay) {
+		select {
+		case accepted <- acceptResult{headers: underlay.Headers(), certs: underlay.Certificates()}:
+		default:
+		}
+	}
+
+	listener, err := NewClassicListenerF(serverId, listenAddr,
+		ListenerConfig{ConnectOptions: DefaultConnectOptions()}, acceptF)
+	req.NoError(err)
+	defer func() { _ = listener.Close() }()
+
+	dialer := NewClassicDialer(DialerConfig{
+		Identity: clientId,
+		Endpoint: dialAddr,
+		HelloHeaderProvider: func(peerCertificates []*x509.Certificate, headers map[int32][]byte) error {
+			if len(peerCertificates) == 0 {
+				return errors.New("no peer certificates available to provider")
+			}
+			// derive a header from the peer's verified identity
+			headers[helloHeaderProviderTestHeader] = []byte("peer:" + peerCertificates[0].Subject.CommonName)
+			return nil
+		},
+	})
+
+	underlay, err := dialer.CreateWithHeaders(2*time.Second, nil)
+	req.NoError(err)
+	defer func() { _ = underlay.Close() }()
+
+	select {
+	case result := <-accepted:
+		req.Equal([]byte("peer:test-server"), result.headers[helloHeaderProviderTestHeader],
+			"header derived from the peer's certificates should reach the listener via the hello")
+		req.NotEmpty(result.certs, "listener should see the client's certificates")
+		req.Equal("test-client", result.certs[0].Subject.CommonName)
+	case <-time.After(2 * time.Second):
+		req.Fail("listener did not receive an underlay")
+	}
+}
+
+// Test_HelloHeaderProvider_ErrorAbortsDial verifies that a HelloHeaderProvider returning an
+// error aborts the dial.
+func Test_HelloHeaderProvider_ErrorAbortsDial(t *testing.T) {
+	transport.AddAddressParser(tcp.AddressParser{})
+	req := require.New(t)
+
+	listenAddr, err := transport.ParseAddress("tcp:0.0.0.0:6769")
+	req.NoError(err)
+	dialAddr, err := transport.ParseAddress("tcp:127.0.0.1:6769")
+	req.NoError(err)
+
+	listener, err := NewClassicListenerF(&identity.TokenId{Token: "test-server"}, listenAddr,
+		ListenerConfig{ConnectOptions: DefaultConnectOptions()}, func(underlay Underlay) {})
+	req.NoError(err)
+	defer func() { _ = listener.Close() }()
+
+	var providerCalls atomic.Int32
+	dialer := NewClassicDialer(DialerConfig{
+		Identity: &identity.TokenId{Token: "test-client"},
+		Endpoint: dialAddr,
+		HelloHeaderProvider: func(peerCertificates []*x509.Certificate, headers map[int32][]byte) error {
+			providerCalls.Add(1)
+			return errors.New("provider rejected the connection")
+		},
+	})
+
+	_, err = dialer.CreateWithHeaders(2*time.Second, nil)
+	req.Error(err, "a provider error should abort the dial")
+	req.True(IsNonRetryable(err), "a provider error should be reported as non-retryable")
+	req.Equal(int32(1), providerCalls.Load(),
+		"a provider error must not be retried: the provider should be invoked exactly once")
+}
+
+// newTestTlsIdentities generates an in-memory test PKI (CA plus server and client leaf certs)
+// and returns identities usable for a TLS listener and dialer.
+func newTestTlsIdentities(req *require.Assertions) (serverId *identity.TokenId, clientId *identity.TokenId) {
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	req.NoError(err)
+
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	caDer, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	req.NoError(err)
+	caCert, err := x509.ParseCertificate(caDer)
+	req.NoError(err)
+	caPem := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDer}))
+
+	newLeafIdentity := func(cn string, serial int64, extKeyUsage x509.ExtKeyUsage, isServer bool) *identity.TokenId {
+		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		req.NoError(err)
+
+		template := &x509.Certificate{
+			SerialNumber: big.NewInt(serial),
+			Subject:      pkix.Name{CommonName: cn},
+			NotBefore:    time.Now().Add(-time.Hour),
+			NotAfter:     time.Now().Add(time.Hour),
+			KeyUsage:     x509.KeyUsageDigitalSignature,
+			ExtKeyUsage:  []x509.ExtKeyUsage{extKeyUsage},
+			IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+			DNSNames:     []string{"localhost"},
+		}
+		der, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
+		req.NoError(err)
+		keyDer, err := x509.MarshalECPrivateKey(key)
+		req.NoError(err)
+
+		cfg := identity.Config{
+			Key:  "pem:" + string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDer})),
+			Cert: "pem:" + string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})),
+			CA:   "pem:" + caPem,
+		}
+		if isServer {
+			cfg.ServerCert = cfg.Cert
+		}
+
+		id, err := identity.LoadIdentity(cfg)
+		req.NoError(err)
+		return identity.NewIdentity(id)
+	}
+
+	serverId = newLeafIdentity("test-server", 2, x509.ExtKeyUsageServerAuth, true)
+	clientId = newLeafIdentity("test-client", 3, x509.ExtKeyUsageClientAuth, false)
+	return serverId, clientId
+}


### PR DESCRIPTION
Fixes #258.

Adds an optional `HelloHeaderProvider` to `DialerConfig`. When set, the classic dialer invokes it after the transport/TLS connection is established (so `peer.PeerCertificates()` is available) and before the hello is sent, then merges the returned headers into the hello. This lets a dialer set hello headers that depend on the verified identity of the peer it actually reached, which is only knowable post-handshake. Returning an error aborts the dial.

Backward compatible: a nil provider preserves existing behavior. No listener-side change, the injected headers flow through the existing hello path (`ConnectionId`, id token, headers are already read from the dialer's hello on the listener side).

Changes (`classic_dialer.go`, +40/-13):
- `HelloHeaderProvider` type + `DialerConfig.HelloHeaderProvider` field, wired into `NewClassicDialer`
- in `sendHello`, after the peer is available and before `underlay.Tx(request)`, invoke the provider with `peer.PeerCertificates()` and merge its headers into the hello (close + return on error)

Tests added (`hello_header_provider_test.go`): the provider is invoked and its header reaches the listener via the hello; a provider error aborts the dial.

Note: a provider error currently incurs the existing `CreateWithHeaders` retry-once before the dial fails (the dial still aborts). Happy to tighten that to a non-retryable abort if preferred.