### PR TITLE
Add ContentTypeReceiver, a self-describing receive handler

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -51,6 +51,39 @@ func (self ReceiveHandlerF) HandleReceive(m *Message, ch Channel) {
 	self(m, ch)
 }
 
+// ContentTypeReceiver is a receive handler which reports the content type it handles.
+// It allows handlers to be registered without separately specifying the content type,
+// using AddReceiveHandlers.
+type ContentTypeReceiver interface {
+	ContentType() int32
+	ReceiveHandler
+}
+
+// AddReceiveHandlers registers receive handlers which provide their own content type.
+func AddReceiveHandlers(binding Binding, handlers ...ContentTypeReceiver) {
+	for _, h := range handlers {
+		binding.AddReceiveHandler(h.ContentType(), h)
+	}
+}
+
+// AsyncFunctionReceiveAdapter is a ContentTypeReceiver which handles each message
+// in a new goroutine, for handlers which may block or run long. Receive handlers
+// are otherwise invoked on the channel's receive loop.
+type AsyncFunctionReceiveAdapter struct {
+	Type    int32
+	Handler ReceiveHandlerF
+}
+
+// ContentType returns the message content type this handler processes.
+func (adapter *AsyncFunctionReceiveAdapter) ContentType() int32 {
+	return adapter.Type
+}
+
+// HandleReceive dispatches the message to the wrapped handler in a new goroutine.
+func (adapter *AsyncFunctionReceiveAdapter) HandleReceive(m *Message, ch Channel) {
+	go adapter.Handler(m, ch)
+}
+
 // MsgReceiveHandler handles received messages without channel context.
 type MsgReceiveHandler interface {
 	HandleReceive(m *Message)

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,0 +1,93 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package channel
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type recordingBinding struct {
+	Binding
+	handlers map[int32]ReceiveHandler
+}
+
+func (self *recordingBinding) AddReceiveHandler(contentType int32, h ReceiveHandler) {
+	self.handlers[contentType] = h
+}
+
+type testContentTypeReceiver struct {
+	contentType int32
+	received    []*Message
+}
+
+func (self *testContentTypeReceiver) ContentType() int32 {
+	return self.contentType
+}
+
+func (self *testContentTypeReceiver) HandleReceive(m *Message, _ Channel) {
+	self.received = append(self.received, m)
+}
+
+func TestAddReceiveHandlers(t *testing.T) {
+	req := require.New(t)
+
+	binding := &recordingBinding{handlers: map[int32]ReceiveHandler{}}
+
+	first := &testContentTypeReceiver{contentType: 100}
+	second := &testContentTypeReceiver{contentType: 200}
+
+	AddReceiveHandlers(binding, first, second)
+
+	req.Len(binding.handlers, 2)
+
+	msg := NewMessage(100, nil)
+	binding.handlers[100].HandleReceive(msg, nil)
+	req.Equal([]*Message{msg}, first.received)
+	req.Empty(second.received)
+
+	binding.handlers[200].HandleReceive(msg, nil)
+	req.Len(second.received, 1)
+}
+
+func TestAsyncFunctionReceiveAdapter(t *testing.T) {
+	req := require.New(t)
+
+	binding := &recordingBinding{handlers: map[int32]ReceiveHandler{}}
+
+	received := make(chan *Message, 1)
+	AddReceiveHandlers(binding, &AsyncFunctionReceiveAdapter{
+		Type: 100,
+		Handler: func(m *Message, ch Channel) {
+			received <- m
+		},
+	})
+
+	req.Len(binding.handlers, 1)
+
+	msg := NewMessage(100, nil)
+	binding.handlers[100].HandleReceive(msg, nil)
+
+	select {
+	case m := <-received:
+		req.Equal(msg, m)
+	case <-time.After(time.Second):
+		req.Fail("timed out waiting for async handler dispatch")
+	}
+}


### PR DESCRIPTION
Fixes #261

v4's `TypedReceiveHandler` (a receive handler that reports the content type it handles) was removed in v5, and the name now refers to the senders-typed handler. Consumers use the self-describing pattern heavily, so bring it back under a non-colliding name:

- `ContentTypeReceiver`: `ContentType() int32` plus `ReceiveHandler`
- `AddReceiveHandlers(binding, handlers...)`: a variadic free function rather than a `Binding` method, so `Binding` implementations and wrappers are unaffected
- `AsyncFunctionReceiveAdapter`: restored with its v4 name and shape as a `ContentTypeReceiver` implementation, so consumer code using it migrates with no changes beyond the import path