### PR TITLE
Multi-underlay reconnect fix + runtime heartbeat interval reconfiguration

### DIFF
--- a/classic_listener.go
+++ b/classic_listener.go
@@ -36,7 +36,7 @@ type classicListener struct {
 	socket          io.Closer
 	close           chan struct{}
 	handlers        []ConnectionHandler
-	acceptF         func(underlay Underlay)
+	acceptor        HelloAcceptor
 	created         chan Underlay
 	connectOptions  ConnectOptions
 	tcfg            transport.Configuration
@@ -105,7 +105,7 @@ func newClassicListener(identity *identity.TokenId, endpoint transport.Address, 
 		socket:          nil,
 		close:           closeNotify,
 		handlers:        config.ConnectionHandlers,
-		acceptF:         nil,
+		acceptor:        nil,
 		created:         nil,
 		connectOptions:  config.ConnectOptions,
 		tcfg:            config.TransportConfig,
@@ -119,9 +119,17 @@ func newClassicListener(identity *identity.TokenId, endpoint transport.Address, 
 }
 
 // NewClassicListenerF creates a classic listener that calls f for each accepted underlay.
+// f is invoked after the hello is acknowledged; use NewClassicListenerWithAcceptor for an
+// acceptor that needs to record state before the acknowledgement.
 func NewClassicListenerF(identity *identity.TokenId, endpoint transport.Address, config ListenerConfig, f func(underlay Underlay)) (io.Closer, error) {
+	return NewClassicListenerWithAcceptor(identity, endpoint, config, HelloAcceptorF(f))
+}
+
+// NewClassicListenerWithAcceptor creates a classic listener that hands each accepted
+// underlay to the given HelloAcceptor, which controls when the hello is acknowledged.
+func NewClassicListenerWithAcceptor(identity *identity.TokenId, endpoint transport.Address, config ListenerConfig, acceptor HelloAcceptor) (io.Closer, error) {
 	listener := newClassicListener(identity, endpoint, config)
-	listener.acceptF = f
+	listener.acceptor = acceptor
 	if err := listener.Listen(); err != nil {
 		return nil, err
 	}
@@ -132,14 +140,14 @@ func NewClassicListenerF(identity *identity.TokenId, endpoint transport.Address,
 func NewClassicListener(identity *identity.TokenId, endpoint transport.Address, config ListenerConfig) UnderlayListener {
 	listener := newClassicListener(identity, endpoint, config)
 	listener.created = make(chan Underlay)
-	listener.acceptF = func(underlay Underlay) {
+	listener.acceptor = HelloAcceptorF(func(underlay Underlay) {
 		select {
 		case listener.created <- underlay:
 		case <-listener.close:
 			pfxlog.Logger().WithField("underlay", underlay.Label()).Info("channel closed, can't notify of new connection")
 			return
 		}
-	}
+	})
 	return listener
 }
 
@@ -238,12 +246,12 @@ func (self *classicListener) acceptConnection(peer transport.Conn) {
 
 		impl.init(hello.IdToken, connectionId, hello.Headers)
 
-		if err = self.ackHello(impl, request, true, ""); err == nil {
-			self.acceptF(impl)
-		} else {
-			log.Errorf("error acknowledging hello for [%s] (%v)", peer.Detail().Address, err)
-			_ = peer.Close()
-		}
+		// Hand the underlay to the acceptor, which decides when to acknowledge the hello.
+		// Deferring the ack lets the acceptor record state (e.g. register a group) before
+		// the peer is released to dial additional underlays.
+		self.acceptor.AcceptUnderlay(impl, func() error {
+			return self.ackHello(impl, request, true, "")
+		})
 	})
 	if err != nil {
 		log.WithError(err).Error("failed to queue connection accept")

--- a/heartbeater.go
+++ b/heartbeater.go
@@ -99,6 +99,18 @@ type HeartbeatCallback interface {
 	CheckHeartBeat()
 }
 
+// HeartbeatControl retunes the heartbeat timing of a running channel. It is
+// returned by ConfigureHeartbeat so a caller can change the send and check
+// intervals without rebuilding the channel, for example when applying updated
+// configuration to an established link. UpdateIntervals is meant to be called
+// from a single goroutine per channel.
+type HeartbeatControl interface {
+	// UpdateIntervals changes the heartbeat send and check intervals. The send
+	// interval takes effect on the next outbound message; the check interval on
+	// the next pulse of the heartbeat loop.
+	UpdateIntervals(sendInterval, checkInterval time.Duration)
+}
+
 // ConfigureHeartbeat setups up heartbeats on the given channel. It assumes that an equivalent setup happens on the
 // other side of the channel.
 //
@@ -109,30 +121,52 @@ type HeartbeatCallback interface {
 // Similarly, when a message with a heartbeat header is received, the next sent message will have a header set with
 // the heartbeat response. If no message is sent within a few milliseconds, a standalone heartbeat response will be
 // sent
-func ConfigureHeartbeat(binding Binding, heartbeatInterval time.Duration, checkInterval time.Duration, cb HeartbeatCallback) {
+//
+// The returned HeartbeatControl can be used to retune the send and check
+// intervals later without rebuilding the channel.
+func ConfigureHeartbeat(binding Binding, heartbeatInterval time.Duration, checkInterval time.Duration, cb HeartbeatCallback) HeartbeatControl {
 	hb := &heartbeater{
-		ch:                  binding.GetChannel(),
-		heartBeatIntervalNs: heartbeatInterval.Nanoseconds(),
-		callback:            cb,
-		events:              make(chan heartbeatEvent, 4),
+		ch:        binding.GetChannel(),
+		callback:  cb,
+		events:    make(chan heartbeatEvent, 4),
+		reconfigC: make(chan time.Duration, 1),
 	}
+	hb.heartBeatIntervalNs.Store(heartbeatInterval.Nanoseconds())
 
 	binding.AddReceiveHandler(ContentTypeHeartbeat, hb)
 	binding.AddTransformHandler(hb)
 
 	go hb.pulse(checkInterval)
+
+	return hb
 }
 
-// Note: if altering this struct, be sure to account for 64 bit alignment on 32 bit arm arch
-// https://pkg.go.dev/sync/atomic#pkg-note-BUG
-// https://github.com/golang/go/issues/36606
+// UpdateIntervals implements HeartbeatControl.
+func (self *heartbeater) UpdateIntervals(sendInterval, checkInterval time.Duration) {
+	self.heartBeatIntervalNs.Store(sendInterval.Nanoseconds())
+
+	// The pulse goroutine owns the ticker, so hand the new check interval to it
+	// rather than touching the ticker here. Drain any value pulse hasn't
+	// consumed so the latest request wins, and keep the send non-blocking so
+	// callers never stall on a busy pulse loop.
+	select {
+	case <-self.reconfigC:
+	default:
+	}
+	select {
+	case self.reconfigC <- checkInterval:
+	default:
+	}
+}
+
 type heartbeater struct {
 	ch                   Channel
-	lastHeartbeatTx      int64
-	heartBeatIntervalNs  int64
-	unrespondedHeartbeat int64
+	lastHeartbeatTx      atomic.Int64
+	heartBeatIntervalNs  atomic.Int64
+	unrespondedHeartbeat atomic.Int64
 	callback             HeartbeatCallback
 	events               chan heartbeatEvent
+	reconfigC            chan time.Duration
 }
 
 func (self *heartbeater) HandleReceive(*Message, Channel) {
@@ -161,15 +195,15 @@ func (self *heartbeater) Tx(m *Message, _ Channel) {
 		return
 	}
 	now := time.Now().UnixNano()
-	if now-self.lastHeartbeatTx > self.heartBeatIntervalNs {
+	if now-self.lastHeartbeatTx.Load() > self.heartBeatIntervalNs.Load() {
 		m.PutUint64Header(HeartbeatHeader, uint64(now))
-		atomic.StoreInt64(&self.lastHeartbeatTx, now)
+		self.lastHeartbeatTx.Store(now)
 		self.queueEvent(heartbeatTxEvent(now))
 	}
 
-	if unrespondedHeartbeat := atomic.LoadInt64(&self.unrespondedHeartbeat); unrespondedHeartbeat != 0 {
+	if unrespondedHeartbeat := self.unrespondedHeartbeat.Load(); unrespondedHeartbeat != 0 {
 		m.PutUint64Header(HeartbeatResponseHeader, uint64(unrespondedHeartbeat))
-		atomic.StoreInt64(&self.unrespondedHeartbeat, 0)
+		self.unrespondedHeartbeat.Store(0)
 		self.queueEvent(heartbeatRespTxEvent(now))
 	}
 }
@@ -182,14 +216,21 @@ func (self *heartbeater) pulse(checkInterval time.Duration) {
 		select {
 		case tick := <-ticker.C:
 			now := tick.UnixNano()
-			lastHeartbeatTx := atomic.LoadInt64(&self.lastHeartbeatTx)
-			if now-lastHeartbeatTx > self.heartBeatIntervalNs {
+			lastHeartbeatTx := self.lastHeartbeatTx.Load()
+			if now-lastHeartbeatTx > self.heartBeatIntervalNs.Load() {
 				self.sendHeartbeat()
 			}
 			self.callback.CheckHeartBeat()
 
 		case event := <-self.events:
 			event.handle(self)
+
+		case newCheckInterval := <-self.reconfigC:
+			// time.Ticker.Reset panics on a non-positive duration, so ignore
+			// invalid requests and keep the current interval.
+			if newCheckInterval > 0 {
+				ticker.Reset(newCheckInterval)
+			}
 		}
 	}
 }
@@ -225,7 +266,7 @@ func (h heartbeatTxEvent) handle(heartbeater *heartbeater) {
 type heartbeatRxEvent int64
 
 func (h heartbeatRxEvent) handle(heartbeater *heartbeater) {
-	atomic.StoreInt64(&heartbeater.unrespondedHeartbeat, int64(h))
+	heartbeater.unrespondedHeartbeat.Store(int64(h))
 	heartbeater.callback.HeartbeatRx(int64(h))
 
 	// wait a few milliseconds to allowing already queued traffic to respond to the heartbeat
@@ -252,7 +293,7 @@ func (h heartbeatRespRxEvent) handle(heartbeater *heartbeater) {
 type handleUnresponded struct{}
 
 func (h handleUnresponded) handle(heartbeater *heartbeater) {
-	if unrespondedHeartbeat := atomic.LoadInt64(&heartbeater.unrespondedHeartbeat); unrespondedHeartbeat != 0 {
+	if unrespondedHeartbeat := heartbeater.unrespondedHeartbeat.Load(); unrespondedHeartbeat != 0 {
 		heartbeater.sendHeartbeatIfQueueFree()
 	}
 }

--- a/heartbeater_test.go
+++ b/heartbeater_test.go
@@ -37,9 +37,41 @@ func Test64BitAlignment(t *testing.T) {
 	hb := heartbeater{}
 	chImpl := channelImpl{}
 
-	atomic.LoadInt64(&hb.lastHeartbeatTx)
-	atomic.LoadInt64(&hb.unrespondedHeartbeat)
+	hb.lastHeartbeatTx.Load()
+	hb.unrespondedHeartbeat.Load()
 	atomic.LoadInt64(&chImpl.lastRead)
+}
+
+func Test_UpdateIntervals(t *testing.T) {
+	req := require.New(t)
+
+	hb := &heartbeater{reconfigC: make(chan time.Duration, 1)}
+	hb.heartBeatIntervalNs.Store((10 * time.Second).Nanoseconds())
+
+	hb.UpdateIntervals(2*time.Second, 250*time.Millisecond)
+
+	// send interval is applied immediately, on the field the Tx path reads
+	req.Equal((2 * time.Second).Nanoseconds(), hb.heartBeatIntervalNs.Load())
+
+	// check interval is handed to the pulse goroutine via reconfigC
+	select {
+	case got := <-hb.reconfigC:
+		req.Equal(250*time.Millisecond, got)
+	default:
+		req.Fail("expected a check interval to be queued on reconfigC")
+	}
+
+	// a second update with reconfigC already full coalesces to the latest
+	// value rather than blocking
+	hb.UpdateIntervals(3*time.Second, 100*time.Millisecond)
+	hb.UpdateIntervals(4*time.Second, 50*time.Millisecond)
+	req.Equal((4 * time.Second).Nanoseconds(), hb.heartBeatIntervalNs.Load())
+	select {
+	case got := <-hb.reconfigC:
+		req.Equal(50*time.Millisecond, got, "latest check interval should win")
+	default:
+		req.Fail("expected the coalesced check interval to be queued")
+	}
 }
 
 func TestBaselineHeartbeat(t *testing.T) {

--- a/hello_acceptor.go
+++ b/hello_acceptor.go
@@ -1,0 +1,94 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package channel
+
+import "github.com/michaelquigley/pfxlog"
+
+// HelloAcceptor takes ownership of an underlay whose hello has been received but not
+// yet acknowledged. Implementations must call ackHello exactly once before using the
+// underlay for application traffic, and must close the underlay if they do not accept
+// it (including when ackHello returns an error).
+//
+// Deferring the ack lets an acceptor record state keyed off the underlay before the
+// peer is released by the acknowledgement. MultiListener uses this to register a group
+// before acking, so a racing subsequent underlay for the same group cannot reach the
+// listener before the group is known.
+type HelloAcceptor interface {
+	AcceptUnderlay(underlay Underlay, ackHello func() error)
+}
+
+// HelloAcceptorF adapts a plain accept function into a HelloAcceptor that acknowledges
+// the hello and then hands off the underlay: the original single-phase behavior, with
+// no reservation before the ack.
+type HelloAcceptorF func(underlay Underlay)
+
+// AcceptUnderlay acknowledges the hello and, on success, passes the underlay to the
+// wrapped function. If the acknowledgement fails the underlay is closed.
+func (f HelloAcceptorF) AcceptUnderlay(underlay Underlay, ackHello func() error) {
+	if err := ackHello(); err != nil {
+		pfxlog.Logger().WithError(err).Error("error acknowledging hello")
+		_ = underlay.Close()
+		return
+	}
+	f(underlay)
+}
+
+// AsHelloAcceptor adapts a legacy UnderlayAcceptor (which receives an already-acknowledged
+// underlay) into a HelloAcceptor by acknowledging the hello before handing the underlay
+// off. Use it for single-underlay acceptors, which don't need to reserve state before the
+// ack; multi-underlay acceptors should implement HelloAcceptor directly.
+func AsHelloAcceptor(acceptor UnderlayAcceptor) HelloAcceptor {
+	return HelloAcceptorF(func(underlay Underlay) {
+		if err := acceptor.AcceptUnderlay(underlay); err != nil {
+			pfxlog.Logger().WithError(err).Error("error handling incoming connection, closing connection")
+			if closeErr := underlay.Close(); closeErr != nil {
+				pfxlog.Logger().WithError(closeErr).Info("error closing connection")
+			}
+		}
+	})
+}
+
+// TypeRoutingAcceptor is a HelloAcceptor that routes each underlay to a per-type
+// HelloAcceptor based on its TypeHeader, falling back to DefaultAcceptor when the type
+// is absent or unrecognized. It is the ack-aware analog of UnderlayDispatcher for use
+// with NewClassicListenerWithAcceptor, letting multi-underlay acceptors reserve state
+// before the hello is acknowledged.
+type TypeRoutingAcceptor struct {
+	Acceptors       map[string]HelloAcceptor
+	DefaultAcceptor HelloAcceptor
+}
+
+// AcceptUnderlay routes the underlay to the acceptor registered for its TypeHeader, or to
+// the default acceptor. If no acceptor applies the underlay is closed without acking.
+func (self *TypeRoutingAcceptor) AcceptUnderlay(underlay Underlay, ackHello func() error) {
+	acceptor := self.DefaultAcceptor
+	if chanType, found := underlay.Headers()[TypeHeader]; found {
+		if typed, ok := self.Acceptors[string(chanType)]; ok {
+			acceptor = typed
+		}
+	}
+
+	if acceptor == nil {
+		pfxlog.Logger().Warn("incoming request didn't have a recognized type header, and no default acceptor defined. closing connection")
+		if err := underlay.Close(); err != nil {
+			pfxlog.Logger().WithError(err).Info("error closing connection")
+		}
+		return
+	}
+
+	acceptor.AcceptUnderlay(underlay, ackHello)
+}

--- a/hello_acceptor_test.go
+++ b/hello_acceptor_test.go
@@ -1,0 +1,108 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package channel
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newTypedTestUnderlay(connId, underlayType string) *testUnderlay {
+	return &testUnderlay{
+		headers:      map[int32][]byte{TypeHeader: []byte(underlayType)},
+		connectionId: connId,
+	}
+}
+
+// recordingHelloAcceptor records the underlays it accepts and counts successful acks.
+type recordingHelloAcceptor struct {
+	accepted []Underlay
+	acked    int
+}
+
+func (self *recordingHelloAcceptor) AcceptUnderlay(underlay Underlay, ackHello func() error) {
+	if err := ackHello(); err == nil {
+		self.acked++
+	}
+	self.accepted = append(self.accepted, underlay)
+}
+
+func Test_TypeRoutingAcceptor_RoutesByType(t *testing.T) {
+	a := &recordingHelloAcceptor{}
+	b := &recordingHelloAcceptor{}
+	def := &recordingHelloAcceptor{}
+
+	router := &TypeRoutingAcceptor{
+		Acceptors:       map[string]HelloAcceptor{"a": a, "b": b},
+		DefaultAcceptor: def,
+	}
+
+	router.AcceptUnderlay(newTypedTestUnderlay("1", "a"), ackOK)
+	router.AcceptUnderlay(newTypedTestUnderlay("2", "b"), ackOK)
+	router.AcceptUnderlay(newTypedTestUnderlay("3", "unknown"), ackOK)
+
+	require.Len(t, a.accepted, 1, "type 'a' should route to acceptor a")
+	require.Len(t, b.accepted, 1, "type 'b' should route to acceptor b")
+	require.Len(t, def.accepted, 1, "unknown type should route to the default acceptor")
+}
+
+func Test_TypeRoutingAcceptor_NoAcceptorClosesWithoutAck(t *testing.T) {
+	router := &TypeRoutingAcceptor{Acceptors: map[string]HelloAcceptor{}}
+
+	underlay := newTypedTestUnderlay("1", "unknown")
+	acked := false
+	router.AcceptUnderlay(underlay, func() error { acked = true; return nil })
+
+	require.True(t, underlay.closed, "underlay should be closed when no acceptor applies")
+	require.False(t, acked, "hello should not be acked when no acceptor applies")
+}
+
+// legacyUnderlayAcceptor implements the (post-ack) UnderlayAcceptor interface.
+type legacyUnderlayAcceptor struct {
+	accepted []Underlay
+	err      error
+}
+
+func (self *legacyUnderlayAcceptor) AcceptUnderlay(underlay Underlay) error {
+	self.accepted = append(self.accepted, underlay)
+	return self.err
+}
+
+func Test_AsHelloAcceptor_AcksThenDelegates(t *testing.T) {
+	legacy := &legacyUnderlayAcceptor{}
+	acceptor := AsHelloAcceptor(legacy)
+
+	underlay := newTypedTestUnderlay("1", "x")
+	acked := false
+	acceptor.AcceptUnderlay(underlay, func() error { acked = true; return nil })
+
+	require.True(t, acked, "hello should be acked before delegating")
+	require.Len(t, legacy.accepted, 1, "underlay should be delegated to the legacy acceptor")
+	require.False(t, underlay.closed, "underlay should not be closed on success")
+}
+
+func Test_AsHelloAcceptor_ClosesOnLegacyError(t *testing.T) {
+	legacy := &legacyUnderlayAcceptor{err: errors.New("boom")}
+	acceptor := AsHelloAcceptor(legacy)
+
+	underlay := newTypedTestUnderlay("1", "x")
+	acceptor.AcceptUnderlay(underlay, ackOK)
+
+	require.True(t, underlay.closed, "underlay should be closed when the legacy acceptor errors")
+}

--- a/multi_listener.go
+++ b/multi_listener.go
@@ -42,7 +42,12 @@ type MultiListener struct {
 }
 
 // AcceptUnderlay routes an incoming underlay to an existing channel or creates a new one.
-func (self *MultiListener) AcceptUnderlay(underlay Underlay) {
+// It implements HelloAcceptor: for a grouped first connection it registers the group
+// (reserving its id) before acknowledging the hello, so the ack - which releases the
+// dialer to dial subsequent underlays - cannot precede the group being known. A
+// subsequent underlay therefore always finds either the channel or a create-in-progress
+// notifier and attaches, rather than racing group creation and being rejected.
+func (self *MultiListener) AcceptUnderlay(underlay Underlay, ackHello func() error) {
 	isGrouped, _ := Headers(underlay.Headers()).GetBoolHeader(IsGroupedHeader)
 
 	log := pfxlog.Logger().
@@ -51,6 +56,11 @@ func (self *MultiListener) AcceptUnderlay(underlay Underlay) {
 		WithField("isGrouped", isGrouped)
 
 	if !isGrouped {
+		if err := ackHello(); err != nil {
+			log.WithError(err).Error("error acknowledging hello")
+			_ = underlay.Close()
+			return
+		}
 		if err := self.ungroupedChannelFallback(underlay); err != nil {
 			log.WithError(err).Error("failed to create channel")
 			if closeErr := underlay.Close(); closeErr != nil {
@@ -79,6 +89,20 @@ func (self *MultiListener) AcceptUnderlay(underlay Underlay) {
 			var createLockExists bool
 			waitFor, createLockExists = self.createNotifiers[chId]
 			if !createLockExists {
+				if !isFirst {
+					// No channel and no create in progress for a non-first underlay: its group
+					// is gone (or this is a stale/old-iteration underlay). Close without acking
+					// so the dialer's create fails promptly rather than seeing a short-lived,
+					// acked-then-closed underlay. This cannot happen for a live reconnect: the
+					// group's first connection registers the notifier below before its own ack
+					// releases the dialer to dial these subsequent underlays.
+					self.lock.Unlock()
+					log.Info("no existing channel found for non-first underlay, closing connection")
+					if err := underlay.Close(); err != nil {
+						log.WithError(err).Error("error closing underlay")
+					}
+					return
+				}
 				createLockNotifier = make(chan struct{})
 				self.createNotifiers[chId] = createLockNotifier
 				done = true
@@ -100,6 +124,21 @@ func (self *MultiListener) AcceptUnderlay(underlay Underlay) {
 		}
 	}
 
+	// The group is now registered (an existing channel, or our create-in-progress
+	// notifier). Acknowledge the hello: this releases the dialer to dial subsequent
+	// underlays, which will now find the group rather than racing its creation.
+	if err := ackHello(); err != nil {
+		log.WithError(err).Error("error acknowledging hello")
+		if createLockNotifier != nil {
+			self.lock.Lock()
+			delete(self.createNotifiers, chId)
+			close(createLockNotifier)
+			self.lock.Unlock()
+		}
+		_ = underlay.Close()
+		return
+	}
+
 	if createLockNotifier != nil {
 		defer func() {
 			self.lock.Lock()
@@ -115,14 +154,6 @@ func (self *MultiListener) AcceptUnderlay(underlay Underlay) {
 			log.WithError(err).Error("error accepting underlay")
 		}
 	} else {
-		if !isFirst {
-			log.Info("no existing channel found for underlay, but isFirstGroupConnection not set, closing connection")
-			if err := underlay.Close(); err != nil {
-				log.WithError(err).Error("error closing underlay")
-			}
-			return
-		}
-
 		log.Info("no existing channel found for underlay")
 		var err error
 		ch, err = self.multiChannelFactory(underlay, func() {

--- a/multi_listener_test.go
+++ b/multi_listener_test.go
@@ -48,6 +48,17 @@ func newUngroupedTestUnderlay(connId string) *testUnderlay {
 	}
 }
 
+// ackOK is a no-op hello acknowledgement for tests that don't care about ack timing.
+func ackOK() error { return nil }
+
+// helloAcceptorFunc adapts a full-signature accept function to a HelloAcceptor, for
+// callers that need control over the ack (e.g. to wrap the underlay first).
+type helloAcceptorFunc func(underlay Underlay, ackHello func() error)
+
+func (f helloAcceptorFunc) AcceptUnderlay(underlay Underlay, ackHello func() error) {
+	f(underlay, ackHello)
+}
+
 func Test_MultiListener_FirstGroupedCreatesChannel(t *testing.T) {
 	var factoryCalled atomic.Bool
 
@@ -58,7 +69,7 @@ func Test_MultiListener_FirstGroupedCreatesChannel(t *testing.T) {
 		return errors.New("ungrouped not expected")
 	})
 
-	ml.AcceptUnderlay(newGroupedTestUnderlay("conn-1", true))
+	ml.AcceptUnderlay(newGroupedTestUnderlay("conn-1", true), ackOK)
 
 	require.True(t, factoryCalled.Load())
 
@@ -77,9 +88,11 @@ func Test_MultiListener_NonFirstWithNoExistingChannelClosesUnderlay(t *testing.T
 	})
 
 	underlay := newGroupedTestUnderlay("conn-1", false)
-	ml.AcceptUnderlay(underlay)
+	acked := false
+	ml.AcceptUnderlay(underlay, func() error { acked = true; return nil })
 
-	require.True(t, underlay.closed, "underlay should be closed when not first and no existing channel")
+	require.True(t, underlay.closed, "underlay should be closed when not first and no group exists")
+	require.False(t, acked, "hello should not be acked when rejecting a non-first underlay with no group")
 }
 
 func Test_MultiListener_UngroupedDelegatesToFallback(t *testing.T) {
@@ -93,7 +106,7 @@ func Test_MultiListener_UngroupedDelegatesToFallback(t *testing.T) {
 		return nil
 	})
 
-	ml.AcceptUnderlay(newUngroupedTestUnderlay("conn-1"))
+	ml.AcceptUnderlay(newUngroupedTestUnderlay("conn-1"), ackOK)
 
 	require.True(t, fallbackCalled.Load())
 }
@@ -106,7 +119,7 @@ func Test_MultiListener_UngroupedFallbackErrorClosesUnderlay(t *testing.T) {
 	})
 
 	underlay := newUngroupedTestUnderlay("conn-1")
-	ml.AcceptUnderlay(underlay)
+	ml.AcceptUnderlay(underlay, ackOK)
 
 	require.True(t, underlay.closed, "underlay should be closed when fallback errors")
 }
@@ -119,7 +132,7 @@ func Test_MultiListener_FactoryNilNilReturnsError(t *testing.T) {
 	})
 
 	underlay := newGroupedTestUnderlay("conn-1", true)
-	ml.AcceptUnderlay(underlay)
+	ml.AcceptUnderlay(underlay, ackOK)
 
 	require.True(t, underlay.closed, "underlay should be closed when factory returns nil/nil")
 
@@ -138,9 +151,9 @@ func Test_MultiListener_SecondUnderlayRoutedToExistingChannel(t *testing.T) {
 		return nil
 	})
 
-	ml.AcceptUnderlay(newGroupedTestUnderlay("conn-1", true))
+	ml.AcceptUnderlay(newGroupedTestUnderlay("conn-1", true), ackOK)
 
-	ml.AcceptUnderlay(newGroupedTestUnderlay("conn-1", false))
+	ml.AcceptUnderlay(newGroupedTestUnderlay("conn-1", false), ackOK)
 
 	require.Equal(t, 1, ch.acceptCount, "second underlay should be accepted by existing channel")
 }
@@ -162,12 +175,12 @@ func Test_MultiListener_ConcurrentFirstUnderlaySameId(t *testing.T) {
 
 	go func() {
 		defer wg.Done()
-		ml.AcceptUnderlay(newGroupedTestUnderlay("conn-1", true))
+		ml.AcceptUnderlay(newGroupedTestUnderlay("conn-1", true), ackOK)
 	}()
 
 	go func() {
 		defer wg.Done()
-		ml.AcceptUnderlay(newGroupedTestUnderlay("conn-1", true))
+		ml.AcceptUnderlay(newGroupedTestUnderlay("conn-1", true), ackOK)
 	}()
 
 	// Wait for factory to be called once, then release
@@ -191,7 +204,7 @@ func Test_MultiListener_CloseChannelRemovesFromMap(t *testing.T) {
 		return nil
 	})
 
-	ml.AcceptUnderlay(newGroupedTestUnderlay("conn-1", true))
+	ml.AcceptUnderlay(newGroupedTestUnderlay("conn-1", true), ackOK)
 
 	ml.lock.Lock()
 	_, exists := ml.channels["conn-1"]
@@ -204,6 +217,103 @@ func Test_MultiListener_CloseChannelRemovesFromMap(t *testing.T) {
 	_, exists = ml.channels["conn-1"]
 	ml.lock.Unlock()
 	require.False(t, exists)
+}
+
+// Test_MultiListener_GroupReservedBeforeAck verifies the core ordering guarantee: when
+// a grouped first connection's hello is acknowledged, the group is already registered
+// (a channel or a create-in-progress notifier). The ack is what releases the dialer to
+// dial subsequent underlays, so reserving before it ensures those underlays can never
+// reach the listener before the group is known.
+func Test_MultiListener_GroupReservedBeforeAck(t *testing.T) {
+	ml := NewMultiListener(func(underlay Underlay, closeCallback func()) (Channel, error) {
+		return &testChannel{connId: underlay.ConnectionId()}, nil
+	}, func(underlay Underlay) error {
+		return errors.New("ungrouped not expected")
+	})
+
+	reservedAtAck := false
+	ml.AcceptUnderlay(newGroupedTestUnderlay("conn-1", true), func() error {
+		ml.lock.Lock()
+		_, hasChannel := ml.channels["conn-1"]
+		_, hasNotifier := ml.createNotifiers["conn-1"]
+		ml.lock.Unlock()
+		reservedAtAck = hasChannel || hasNotifier
+		return nil
+	})
+
+	require.True(t, reservedAtAck, "group must be reserved before the hello is acknowledged")
+}
+
+// Test_MultiListener_AckFailureReleasesReservation verifies that if the hello ack fails
+// for a first connection, the reservation is released (so future dials on that id aren't
+// stranded) and no channel is created.
+func Test_MultiListener_AckFailureReleasesReservation(t *testing.T) {
+	factoryCalled := false
+	ml := NewMultiListener(func(underlay Underlay, closeCallback func()) (Channel, error) {
+		factoryCalled = true
+		return &testChannel{connId: underlay.ConnectionId()}, nil
+	}, func(underlay Underlay) error {
+		return errors.New("ungrouped not expected")
+	})
+
+	underlay := newGroupedTestUnderlay("conn-1", true)
+	ml.AcceptUnderlay(underlay, func() error { return errors.New("ack failed") })
+
+	require.True(t, underlay.closed, "underlay should be closed when the ack fails")
+	require.False(t, factoryCalled, "channel should not be created when the ack fails")
+
+	ml.lock.Lock()
+	_, hasChannel := ml.channels["conn-1"]
+	_, hasNotifier := ml.createNotifiers["conn-1"]
+	ml.lock.Unlock()
+	require.False(t, hasChannel, "no channel should be registered after an ack failure")
+	require.False(t, hasNotifier, "the create-notifier should be released after an ack failure")
+}
+
+// Test_MultiListener_NonFirstAttachesWhileFirstInFlight verifies the reconnect-race fix:
+// a subsequent underlay that arrives while its group's first connection is still being
+// created waits for the group and attaches, rather than being rejected.
+func Test_MultiListener_NonFirstAttachesWhileFirstInFlight(t *testing.T) {
+	var ch *testChannel
+	var factoryCallCount atomic.Int32
+	factoryGate := make(chan struct{})
+
+	ml := NewMultiListener(func(underlay Underlay, closeCallback func()) (Channel, error) {
+		factoryCallCount.Add(1)
+		<-factoryGate
+		ch = &testChannel{connId: underlay.ConnectionId()}
+		return ch, nil
+	}, func(underlay Underlay) error {
+		return errors.New("ungrouped not expected")
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// First connection enters the (gated) factory, holding the create-notifier.
+	go func() {
+		defer wg.Done()
+		ml.AcceptUnderlay(newGroupedTestUnderlay("conn-1", true), ackOK)
+	}()
+	for factoryCallCount.Load() < 1 {
+		time.Sleep(time.Millisecond)
+	}
+
+	// Subsequent underlay arrives while the first is still being created.
+	nonFirst := newGroupedTestUnderlay("conn-1", false)
+	go func() {
+		defer wg.Done()
+		ml.AcceptUnderlay(nonFirst, ackOK)
+	}()
+
+	// Give the subsequent underlay time to reach the wait, then let the factory finish.
+	time.Sleep(20 * time.Millisecond)
+	close(factoryGate)
+	wg.Wait()
+
+	require.False(t, nonFirst.closed, "subsequent underlay should attach while the first is in flight, not be rejected")
+	require.Equal(t, int32(1), factoryCallCount.Load(), "factory should be called once")
+	require.Equal(t, 1, ch.acceptCount, "subsequent underlay should be accepted by the group's channel")
 }
 
 // testChannel is a minimal Channel implementation for MultiListener tests.

--- a/multi_test.go
+++ b/multi_test.go
@@ -126,13 +126,13 @@ func Test_MultiUnderlayChannels(t *testing.T) {
 		},
 	}
 
-	acceptWrapper := func(underlay Underlay) {
+	acceptor := helloAcceptorFunc(func(underlay Underlay, ackHello func() error) {
 		wrapper := &TypeLoggingUnderlay{
 			wrapped: underlay,
 		}
-		multiListener.AcceptUnderlay(wrapper)
-	}
-	listener, err := NewClassicListenerF(&identity.TokenId{Token: "test-server"}, listenAddr, listenerConfig, acceptWrapper)
+		multiListener.AcceptUnderlay(wrapper, ackHello)
+	})
+	listener, err := NewClassicListenerWithAcceptor(&identity.TokenId{Token: "test-server"}, listenAddr, listenerConfig, acceptor)
 	req.NoError(err)
 	defer func() { _ = listener.Close() }()
 


### PR DESCRIPTION
Two related channel API changes bundled so they ship in a single version.

## Multi-underlay reconnect reject storm (Fixes #264)
Reserve the underlay before acking so a required-underlay reconnect no longer races into a reject storm.

## Reconfigure heartbeat intervals on a running channel (Fixes #265)
`ConfigureHeartbeat` now returns a `HeartbeatControl` whose `UpdateIntervals(send, check)` retunes a live channel's heartbeat timing without rebuilding it. The send interval is stored atomically; the check interval is handed to the pulse goroutine, which owns and resets the ticker. Existing callers that ignore the return value are unaffected.

This is a Go API addition, not a wire change.