### PR TITLE
Single-channel nil-header fix and pluggable per-channel logging

### DIFF
--- a/heartbeater_test.go
+++ b/heartbeater_test.go
@@ -105,6 +105,11 @@ func TestBaselineHeartbeat(t *testing.T) {
 					return
 				}
 				count++
+				// Pace the loop so it doesn't spin flat-out. Unbounded sending pegs the CPU
+				// and starves the tx/rx goroutines, which on a loaded CI runner lets the send
+				// queue back up past the enqueue timeout, an expected backpressure condition
+				// this test isn't meant to provoke. Matches TestBusyHeartbeat.
+				time.Sleep(time.Millisecond)
 			}
 		}()
 	}
@@ -134,6 +139,9 @@ func TestBaselineHeartbeat(t *testing.T) {
 			req.NoError(err)
 		}
 		count++
+		// See the matching note on the server loop above: pace sends so the queue doesn't
+		// saturate under CI load and trip the enqueue timeout.
+		time.Sleep(time.Millisecond)
 	}
 
 	var remoteCount uint64

--- a/heartbeater_test.go
+++ b/heartbeater_test.go
@@ -96,10 +96,13 @@ func TestBaselineHeartbeat(t *testing.T) {
 				remoteDone <- count
 			}()
 
-			for !ch.IsClosed() && !done.Load() {
+			// Loop until the test's time budget elapses, not until the channel closes: a
+			// premature close should surface as a send error reported on errC rather than a
+			// clean exit that the test ignores.
+			for !done.Load() {
 				msg := NewMessage(ContentTypePingType, []byte("hello"))
 				if err := msg.WithTimeout(time.Second).Send(ch); err != nil {
-					if !ch.IsClosed() {
+					if !done.Load() {
 						errC <- err
 					}
 					return
@@ -132,17 +135,20 @@ func TestBaselineHeartbeat(t *testing.T) {
 	defer func() { _ = ch.Close() }()
 
 	var count uint64
-	for !ch.IsClosed() && !done.Load() {
+	// Loop until the time budget elapses. A healthy channel stays open the whole time (it is
+	// only closed by the deferred Close after this loop), so any send error here is a real
+	// failure, asserted unconditionally rather than skipped once the channel has closed.
+	for !done.Load() {
 		msg := NewMessage(ContentTypePingType, []byte("hello"))
-		err := msg.WithTimeout(time.Second).Send(ch)
-		if !ch.IsClosed() {
-			req.NoError(err)
-		}
+		req.NoError(msg.WithTimeout(time.Second).Send(ch))
 		count++
 		// See the matching note on the server loop above: pace sends so the queue doesn't
 		// saturate under CI load and trip the enqueue timeout.
 		time.Sleep(time.Millisecond)
 	}
+	// Guard against a vacuous pass: the channel must have survived the full duration rather
+	// than closing early and skipping the assertions above.
+	req.False(ch.IsClosed(), "channel closed before the test duration elapsed")
 
 	var remoteCount uint64
 	select {

--- a/impl.go
+++ b/impl.go
@@ -193,6 +193,11 @@ type channelImpl struct {
 	validUnderlayTypes    []string
 	applyInProgress       atomic.Bool
 
+	// eventLog is the slog.Logger used for this channel's lifecycle events. It
+	// is resolved once at creation so per-event logging needs no synchronization
+	// or package-global access.
+	eventLog *slog.Logger
+
 	lock      sync.Mutex
 	underlays *Underlays
 }
@@ -262,6 +267,12 @@ func NewChannel(config *Config) (Channel, error) {
 		}
 		return nil, err
 	}
+
+	// Resolve this channel's event logger once, now that creation has succeeded
+	// and just before the first underlay is added. Caching it here keeps
+	// per-event logging free of locks and package-global access; the underlay
+	// events below read impl.eventLog.
+	impl.eventLog = resolveEventLogger(impl.options, impl.logicalName, getLoggerFor())
 
 	// Add and start the first underlay (this triggers UnderlayAdded)
 	impl.underlays.Add(impl, config.Underlay)
@@ -344,9 +355,28 @@ type singleSenders struct {
 func (self *singleSenders) GetDefaultSender() Sender             { return self.sender }
 func (self *singleSenders) HandleTxFailed(string, Sendable) bool { return false }
 
+// isMultiUnderlayCapable reports whether this channel can grow beyond its
+// initial underlay. Only channels with a dial policy (which dials more
+// underlays) or constraints (which require or desire specific underlays) accept
+// or dial additional underlays; a simple channel never does.
+func (self *channelImpl) isMultiUnderlayCapable() bool {
+	return self.dialPolicy != nil || len(self.constraints) > 0
+}
+
 func (self *channelImpl) AcceptUnderlay(underlay Underlay) error {
 	self.lock.Lock()
 	defer self.lock.Unlock()
+
+	// A simple channel never accepts additional underlays. Reject before the
+	// secret check: a secretless simple channel has an empty groupSecret, and
+	// bytes.Equal of two empty secrets would otherwise admit another secretless
+	// underlay.
+	if !self.isMultiUnderlayCapable() {
+		if err := underlay.Close(); err != nil {
+			pfxlog.ContextLogger(self.Label()).WithError(err).Error("error closing underlay")
+		}
+		return fmt.Errorf("new underlay for '%s' not accepted: channel does not accept additional underlays", self.ConnectionId())
+	}
 
 	groupSecret := underlay.Headers()[GroupSecretHeader]
 	if !bytes.Equal(groupSecret, self.groupSecret) {
@@ -664,19 +694,9 @@ func (self *channelImpl) rxer(underlay Underlay, notifier *CloseNotifier) {
 	}
 }
 
-// eventLogger returns the slog.Logger this channel uses for lifecycle events:
-// the per-channel Options.Logger when set, otherwise the package-level
-// LoggerFor / pfxlog default keyed by the channel's logical name.
-func (self *channelImpl) eventLogger() *slog.Logger {
-	if self.options != nil && self.options.Logger != nil {
-		return self.options.Logger
-	}
-	return channelLogger(self.logicalName)
-}
-
 // UnderlayAdded implements UnderlayEventListener. Logs the event.
 func (self *channelImpl) UnderlayAdded(ch Channel, underlay Underlay) {
-	self.eventLogger().Info("underlay added",
+	self.eventLog.Info("underlay added",
 		"id", ch.Label(),
 		"underlays", ch.GetUnderlayCountsByType(),
 		"underlayType", GetUnderlayType(underlay),
@@ -688,7 +708,7 @@ func (self *channelImpl) UnderlayAdded(ch Channel, underlay Underlay) {
 func (self *channelImpl) UnderlayRemoved(ch Channel, underlay Underlay) {
 	lifetime := time.Since(underlay.CreatedAt())
 
-	self.eventLogger().Info("underlay removed",
+	self.eventLog.Info("underlay removed",
 		"id", ch.Label(),
 		"underlays", ch.GetUnderlayCountsByType(),
 		"underlayType", GetUnderlayType(underlay),
@@ -699,9 +719,9 @@ func (self *channelImpl) UnderlayRemoved(ch Channel, underlay Underlay) {
 		self.dialPolicy.UnderlayClosed(self.getValidatedUnderlayType(underlay), lifetime)
 	}
 
-	if len(self.constraints) == 0 && self.dialPolicy == nil {
-		// No constraints or dial policy means this is a simple channel that cannot
-		// recover from underlay loss. If no underlays remain, close the channel.
+	if !self.isMultiUnderlayCapable() {
+		// A simple channel (no constraints, no dial policy) cannot recover from
+		// underlay loss. If no underlays remain, close the channel.
 		if len(self.underlays.GetAll()) == 0 {
 			if err := self.Close(); err != nil {
 				pfxlog.Logger().WithError(err).Error("error closing channel after last underlay removed")

--- a/impl.go
+++ b/impl.go
@@ -238,6 +238,12 @@ func NewChannel(config *Config) (Channel, error) {
 	impl.ownerId = config.Underlay.Id()
 	impl.fallbackUnderlay.Store(&config.Underlay)
 
+	// Resolve this channel's event logger before registering listeners or binding:
+	// a bind handler can reach the channel via Binding.GetChannel() and call
+	// AcceptUnderlay, which fires UnderlayAdded and reads impl.eventLog. Caching it
+	// here keeps per-event logging free of locks and package-global access.
+	impl.eventLog = resolveEventLogger(impl.options, impl.logicalName, getLoggerFor())
+
 	// The group secret matches reconnecting or additional underlays to this channel, so it is
 	// only required for channels that can grow: those with a dial policy (which dials more
 	// underlays) or constraints (which desire more). This mirrors the "simple channel"
@@ -267,12 +273,6 @@ func NewChannel(config *Config) (Channel, error) {
 		}
 		return nil, err
 	}
-
-	// Resolve this channel's event logger once, now that creation has succeeded
-	// and just before the first underlay is added. Caching it here keeps
-	// per-event logging free of locks and package-global access; the underlay
-	// events below read impl.eventLog.
-	impl.eventLog = resolveEventLogger(impl.options, impl.logicalName, getLoggerFor())
 
 	// Add and start the first underlay (this triggers UnderlayAdded)
 	impl.underlays.Add(impl, config.Underlay)

--- a/impl.go
+++ b/impl.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"slices"
 	"sync"
@@ -663,13 +664,23 @@ func (self *channelImpl) rxer(underlay Underlay, notifier *CloseNotifier) {
 	}
 }
 
+// eventLogger returns the slog.Logger this channel uses for lifecycle events:
+// the per-channel Options.Logger when set, otherwise the package-level
+// LoggerFor / pfxlog default keyed by the channel's logical name.
+func (self *channelImpl) eventLogger() *slog.Logger {
+	if self.options != nil && self.options.Logger != nil {
+		return self.options.Logger
+	}
+	return channelLogger(self.logicalName)
+}
+
 // UnderlayAdded implements UnderlayEventListener. Logs the event.
 func (self *channelImpl) UnderlayAdded(ch Channel, underlay Underlay) {
-	pfxlog.Logger().
-		WithField("id", ch.Label()).
-		WithField("underlays", ch.GetUnderlayCountsByType()).
-		WithField("underlayType", GetUnderlayType(underlay)).
-		Info("underlay added")
+	self.eventLogger().Info("underlay added",
+		"id", ch.Label(),
+		"underlays", ch.GetUnderlayCountsByType(),
+		"underlayType", GetUnderlayType(underlay),
+	)
 }
 
 // UnderlayRemoved implements UnderlayEventListener. Reports the underlay's lifetime to the
@@ -677,12 +688,12 @@ func (self *channelImpl) UnderlayAdded(ch Channel, underlay Underlay) {
 func (self *channelImpl) UnderlayRemoved(ch Channel, underlay Underlay) {
 	lifetime := time.Since(underlay.CreatedAt())
 
-	pfxlog.Logger().
-		WithField("id", ch.Label()).
-		WithField("underlays", ch.GetUnderlayCountsByType()).
-		WithField("underlayType", GetUnderlayType(underlay)).
-		WithField("lifetime", lifetime).
-		Info("underlay removed")
+	self.eventLogger().Info("underlay removed",
+		"id", ch.Label(),
+		"underlays", ch.GetUnderlayCountsByType(),
+		"underlayType", GetUnderlayType(underlay),
+		"lifetime", lifetime,
+	)
 
 	if self.dialPolicy != nil {
 		self.dialPolicy.UnderlayClosed(self.getValidatedUnderlayType(underlay), lifetime)

--- a/impl.go
+++ b/impl.go
@@ -28,7 +28,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/foundation/v2/concurrenz"
 	"github.com/openziti/foundation/v2/info"
@@ -233,11 +232,16 @@ func NewChannel(config *Config) (Channel, error) {
 	impl.ownerId = config.Underlay.Id()
 	impl.fallbackUnderlay.Store(&config.Underlay)
 
-	groupSecret := config.Underlay.Headers()[GroupSecretHeader]
-	if len(groupSecret) == 0 {
-		return nil, errors.New("no group secret header found for channel")
+	// The group secret matches reconnecting or additional underlays to this channel, so it is
+	// only required for channels that can grow: those with a dial policy (which dials more
+	// underlays) or constraints (which desire more). This mirrors the "simple channel"
+	// definition used elsewhere (no constraints and no dial policy). A simple single-underlay
+	// channel never dials or accepts additional underlays, so it needs no secret. Headers()
+	// may be nil, which indexes safely to a nil slice.
+	impl.groupSecret = config.Underlay.Headers()[GroupSecretHeader]
+	if len(impl.groupSecret) == 0 && (config.DialPolicy != nil || len(config.Constraints) > 0) {
+		return nil, errors.New("no group secret header found for multi-underlay channel")
 	}
-	impl.groupSecret = groupSecret
 
 	// Register the channel as an underlay event listener for constraint enforcement
 	impl.underlays.AddListener(impl)
@@ -293,12 +297,6 @@ func NewSingleChannel(logicalName string, underlayFactory UnderlayFactory, bindH
 // NewSingleChannelWithUnderlay creates a simple channel from an existing underlay, with a single
 // sender and bind handler. Use this when you already have a connected underlay (e.g. from a listener).
 func NewSingleChannelWithUnderlay(logicalName string, underlay Underlay, bindHandler BindHandler, options *Options) (Channel, error) {
-	headers := underlay.Headers()
-	if len(headers[GroupSecretHeader]) == 0 {
-		secret := uuid.New()
-		headers[GroupSecretHeader] = secret[:]
-	}
-
 	outQueueSize := DefaultOutQueueSize
 	if options != nil {
 		outQueueSize = options.OutQueueSize

--- a/impl_test.go
+++ b/impl_test.go
@@ -1,0 +1,85 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package channel
+
+import (
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// blockingUnderlay is a testUnderlay whose Rx blocks until Close, so a channel's rx loop
+// parks instead of spinning on the stub's immediate nil return.
+type blockingUnderlay struct {
+	*testUnderlay
+	closeCh chan struct{}
+	once    sync.Once
+}
+
+func (b *blockingUnderlay) Rx() (*Message, error) {
+	<-b.closeCh
+	return nil, io.EOF
+}
+
+func (b *blockingUnderlay) Close() error {
+	b.once.Do(func() { close(b.closeCh) })
+	return b.testUnderlay.Close()
+}
+
+// TestNewSingleChannelWithoutGroupSecret verifies that a simple single-underlay channel can
+// be created from an underlay that exposes no headers (e.g. a websocket underlay, whose
+// Headers() returns nil). Such a channel never dials or accepts additional underlays, so it
+// needs no group secret; requiring one previously panicked on the nil headers map.
+func TestNewSingleChannelWithoutGroupSecret(t *testing.T) {
+	underlay := &blockingUnderlay{testUnderlay: &testUnderlay{headers: nil}, closeCh: make(chan struct{})}
+
+	var ch Channel
+	require.NotPanics(t, func() {
+		var err error
+		ch, err = NewSingleChannelWithUnderlay("test", underlay, BindHandlerF(func(Binding) error { return nil }), nil)
+		require.NoError(t, err)
+	})
+	require.NotNil(t, ch)
+	require.Empty(t, ch.(*channelImpl).groupSecret)
+	require.NoError(t, ch.Close())
+}
+
+// TestNewChannelMultiUnderlayRequiresGroupSecret verifies the other branch of the guard: a
+// channel that can grow (here, one with constraints) must carry a group secret, since it
+// needs one to match reconnecting or additional underlays. Constructing one without a secret
+// must fail rather than silently produce a channel that can never validate new underlays.
+func TestNewChannelMultiUnderlayRequiresGroupSecret(t *testing.T) {
+	ctx := NewSenderContext()
+	senders := &singleSenders{SenderContext: ctx, sender: NewSingleChSender(ctx, make(chan Sendable, 1))}
+	msgSource := NewSimpleMessageSourceProvider(func(*CloseNotifier) (Sendable, error) { return nil, io.EOF })
+
+	config := &Config{
+		LogicalName:           "test",
+		Underlay:              &testUnderlay{headers: nil},
+		Binder:                MakeBinder(BindHandlerF(func(Binding) error { return nil })),
+		Senders:               senders,
+		MessageSourceProvider: msgSource,
+		Constraints:           map[string]UnderlayConstraint{"default": {Desired: 2, Min: 1}},
+	}
+
+	ch, err := NewChannel(config)
+	require.Error(t, err)
+	require.Nil(t, ch)
+	require.Contains(t, err.Error(), "no group secret")
+}

--- a/impl_test.go
+++ b/impl_test.go
@@ -37,9 +37,15 @@ func (b *blockingUnderlay) Rx() (*Message, error) {
 	return nil, io.EOF
 }
 
+// Close is idempotent and safe to call concurrently. The channel closes its underlay from
+// both Channel.Close and the rx goroutine's deferred cleanup, so without the guard the two
+// races on the embedded testUnderlay's unsynchronized closed flag.
 func (b *blockingUnderlay) Close() error {
-	b.once.Do(func() { close(b.closeCh) })
-	return b.testUnderlay.Close()
+	b.once.Do(func() {
+		close(b.closeCh)
+		_ = b.testUnderlay.Close()
+	})
+	return nil
 }
 
 // TestNewSingleChannelWithoutGroupSecret verifies that a simple single-underlay channel can
@@ -82,4 +88,35 @@ func TestNewChannelMultiUnderlayRequiresGroupSecret(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, ch)
 	require.Contains(t, err.Error(), "no group secret")
+}
+
+// TestSimpleChannelRejectsAdditionalUnderlays verifies that a simple channel (no
+// dial policy, no constraints) refuses additional underlays via AcceptUnderlay,
+// including a secretless one. Without the capability guard, a secretless simple
+// channel's empty groupSecret would bytes.Equal-match another secretless underlay
+// and wrongly admit it.
+func TestSimpleChannelRejectsAdditionalUnderlays(t *testing.T) {
+	underlay := &blockingUnderlay{testUnderlay: &testUnderlay{headers: nil}, closeCh: make(chan struct{})}
+	ch, err := NewSingleChannelWithUnderlay("test", underlay, BindHandlerF(func(Binding) error { return nil }), nil)
+	require.NoError(t, err)
+	require.Empty(t, ch.(*channelImpl).groupSecret)
+	t.Cleanup(func() { _ = ch.Close() })
+
+	impl := ch.(*channelImpl)
+
+	t.Run("secretless underlay rejected and closed", func(t *testing.T) {
+		extra := &testUnderlay{headers: nil}
+		err := impl.AcceptUnderlay(extra)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "does not accept additional underlays")
+		require.True(t, extra.IsClosed(), "rejected underlay should be closed")
+	})
+
+	t.Run("secret-bearing underlay rejected and closed", func(t *testing.T) {
+		extra := &testUnderlay{headers: map[int32][]byte{GroupSecretHeader: []byte("mysecret")}}
+		err := impl.AcceptUnderlay(extra)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "does not accept additional underlays")
+		require.True(t, extra.IsClosed(), "rejected underlay should be closed")
+	})
 }

--- a/logging.go
+++ b/logging.go
@@ -55,14 +55,19 @@ func getLoggerFor() func(name string) *slog.Logger {
 
 // resolveEventLogger picks the logger for a channel event by precedence: the
 // per-channel Options.Logger, then the supplied loggerFor resolver keyed by name,
-// then the pfxlog-backed default. Taking loggerFor as a parameter keeps the
-// precedence logic free of package state so it can be exercised directly.
+// then the pfxlog-backed default. It always returns a non-nil logger: a resolver
+// that returns nil for a name falls through to the default, so the channel never
+// caches a nil logger and panics on its first event. Taking loggerFor as a
+// parameter keeps the precedence logic free of package state so it can be
+// exercised directly.
 func resolveEventLogger(opts *Options, name string, loggerFor func(name string) *slog.Logger) *slog.Logger {
 	if opts != nil && opts.Logger != nil {
 		return opts.Logger
 	}
 	if loggerFor != nil {
-		return loggerFor(name)
+		if logger := loggerFor(name); logger != nil {
+			return logger
+		}
 	}
 	return defaultChannelLogger(name)
 }

--- a/logging.go
+++ b/logging.go
@@ -1,0 +1,144 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package channel
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+
+	"github.com/michaelquigley/pfxlog"
+	"github.com/sirupsen/logrus"
+)
+
+// LoggerFor when set, returns the *slog.Logger that channel uses for events
+// scoped to the given name. The name is the channel's LogicalName (e.g.
+// "ctrl", "link", "agent"), so an embedding application can both route
+// channel logging through its own slog setup and control verbosity per
+// channel type independently of the global level.
+//
+// When nil, channel falls back to a default logger that forwards to
+// pfxlog/logrus, preserving the logging behavior channel had before this seam
+// existed. Applications that wire LoggerFor get accurate source attribution
+// from slog's own caller capture; the pfxlog fallback attributes the call to
+// the forwarding handler, which is a minor cosmetic difference on these
+// events.
+//
+// Set this once during startup before any channels are created.
+var LoggerFor func(name string) *slog.Logger
+
+// channelLogger returns the logger for the given logical name, using LoggerFor
+// when set and the pfxlog-backed default otherwise. Callers that have a
+// per-channel Options.Logger should prefer (*channelImpl).eventLogger, which
+// consults it first.
+func channelLogger(name string) *slog.Logger {
+	if f := LoggerFor; f != nil {
+		return f(name)
+	}
+	return defaultChannelLogger(name)
+}
+
+var (
+	defaultLoggerMu     sync.Mutex
+	defaultLoggerByName = map[string]*slog.Logger{}
+)
+
+// defaultChannelLogger returns (and caches) the pfxlog-backed slog.Logger for
+// a logical name. The name is bound as the "channel" attr so the channel type
+// is visible in output even when no LoggerFor is wired, matching the attr the
+// slog registry would bind.
+func defaultChannelLogger(name string) *slog.Logger {
+	defaultLoggerMu.Lock()
+	defer defaultLoggerMu.Unlock()
+	if logger, ok := defaultLoggerByName[name]; ok {
+		return logger
+	}
+	logger := slog.New(&pfxlogHandler{}).With(slog.String("channel", name))
+	defaultLoggerByName[name] = logger
+	return logger
+}
+
+// pfxlogHandler is the default slog.Handler used when LoggerFor is unset. It
+// forwards records to pfxlog/logrus so channel logging lands wherever the
+// embedding application has already pointed logrus, unchanged from before the
+// LoggerFor seam.
+type pfxlogHandler struct {
+	attrs []slog.Attr
+}
+
+func (h *pfxlogHandler) Enabled(_ context.Context, level slog.Level) bool {
+	return logrus.StandardLogger().IsLevelEnabled(slogToLogrusLevel(level))
+}
+
+func (h *pfxlogHandler) Handle(_ context.Context, r slog.Record) error {
+	entry := pfxlog.Logger().Entry
+	if len(h.attrs) > 0 {
+		entry = entry.WithFields(attrsToFields(h.attrs))
+	}
+	if r.NumAttrs() > 0 {
+		fields := make(logrus.Fields, r.NumAttrs())
+		r.Attrs(func(a slog.Attr) bool {
+			fields[a.Key] = a.Value.Any()
+			return true
+		})
+		entry = entry.WithFields(fields)
+	}
+	entry.Log(slogToLogrusLevel(r.Level), r.Message)
+	return nil
+}
+
+func (h *pfxlogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+	combined := make([]slog.Attr, 0, len(h.attrs)+len(attrs))
+	combined = append(combined, h.attrs...)
+	combined = append(combined, attrs...)
+	return &pfxlogHandler{attrs: combined}
+}
+
+// WithGroup is a no-op; channel does not use slog groups for its events.
+func (h *pfxlogHandler) WithGroup(string) slog.Handler {
+	return h
+}
+
+func attrsToFields(attrs []slog.Attr) logrus.Fields {
+	fields := make(logrus.Fields, len(attrs))
+	for _, a := range attrs {
+		fields[a.Key] = a.Value.Any()
+	}
+	return fields
+}
+
+// slogToLogrusLevel maps a slog.Level onto the nearest logrus level for the
+// pfxlog fallback path.
+func slogToLogrusLevel(l slog.Level) logrus.Level {
+	switch {
+	case l <= slog.LevelDebug-4:
+		return logrus.TraceLevel
+	case l <= slog.LevelDebug:
+		return logrus.DebugLevel
+	case l <= slog.LevelInfo:
+		return logrus.InfoLevel
+	case l <= slog.LevelWarn:
+		return logrus.WarnLevel
+	case l <= slog.LevelError:
+		return logrus.ErrorLevel
+	default:
+		return logrus.ErrorLevel
+	}
+}

--- a/logging.go
+++ b/logging.go
@@ -25,29 +25,44 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// LoggerFor when set, returns the *slog.Logger that channel uses for events
-// scoped to the given name. The name is the channel's LogicalName (e.g.
-// "ctrl", "link", "agent"), so an embedding application can both route
-// channel logging through its own slog setup and control verbosity per
-// channel type independently of the global level.
-//
-// When nil, channel falls back to a default logger that forwards to
-// pfxlog/logrus, preserving the logging behavior channel had before this seam
-// existed. Applications that wire LoggerFor get accurate source attribution
-// from slog's own caller capture; the pfxlog fallback attributes the call to
-// the forwarding handler, which is a minor cosmetic difference on these
-// events.
-//
-// Set this once during startup before any channels are created.
-var LoggerFor func(name string) *slog.Logger
+var (
+	loggerForMu sync.Mutex
+	loggerFor   func(name string) *slog.Logger
+)
 
-// channelLogger returns the logger for the given logical name, using LoggerFor
-// when set and the pfxlog-backed default otherwise. Callers that have a
-// per-channel Options.Logger should prefer (*channelImpl).eventLogger, which
-// consults it first.
-func channelLogger(name string) *slog.Logger {
-	if f := LoggerFor; f != nil {
-		return f(name)
+// SetLoggerFor installs the resolver that channel uses for events scoped to a
+// channel's LogicalName (e.g. "ctrl", "link", "agent"), letting an embedding
+// application route channel logging through its own slog setup and control
+// verbosity per channel type. When no resolver is installed, channel falls back
+// to a default logger that forwards to pfxlog/logrus, preserving the logging
+// behavior channel had before this seam existed.
+//
+// Set this once during startup, before any channels are created. Each channel
+// resolves and caches its logger at creation, so installing a resolver after
+// channels already exist applies only to channels created afterward.
+func SetLoggerFor(f func(name string) *slog.Logger) {
+	loggerForMu.Lock()
+	defer loggerForMu.Unlock()
+	loggerFor = f
+}
+
+// getLoggerFor returns the installed resolver, or nil if none has been set.
+func getLoggerFor() func(name string) *slog.Logger {
+	loggerForMu.Lock()
+	defer loggerForMu.Unlock()
+	return loggerFor
+}
+
+// resolveEventLogger picks the logger for a channel event by precedence: the
+// per-channel Options.Logger, then the supplied loggerFor resolver keyed by name,
+// then the pfxlog-backed default. Taking loggerFor as a parameter keeps the
+// precedence logic free of package state so it can be exercised directly.
+func resolveEventLogger(opts *Options, name string, loggerFor func(name string) *slog.Logger) *slog.Logger {
+	if opts != nil && opts.Logger != nil {
+		return opts.Logger
+	}
+	if loggerFor != nil {
+		return loggerFor(name)
 	}
 	return defaultChannelLogger(name)
 }

--- a/logging_test.go
+++ b/logging_test.go
@@ -1,0 +1,64 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package channel
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestEventLoggerResolution verifies the lifecycle-logger precedence:
+// Options.Logger first, then the package-level LoggerFor, then a non-nil
+// default.
+func TestEventLoggerResolution(t *testing.T) {
+	origLoggerFor := LoggerFor
+	defer func() { LoggerFor = origLoggerFor }()
+
+	optLogger := slog.New(slog.NewTextHandler(nil, nil))
+	globalLogger := slog.New(slog.NewTextHandler(nil, nil))
+
+	t.Run("Options.Logger wins over LoggerFor", func(t *testing.T) {
+		LoggerFor = func(string) *slog.Logger { return globalLogger }
+		ch := &channelImpl{logicalName: "link", options: &Options{Logger: optLogger}}
+		assert.Same(t, optLogger, ch.eventLogger())
+	})
+
+	t.Run("LoggerFor used when Options.Logger nil", func(t *testing.T) {
+		var gotName string
+		LoggerFor = func(name string) *slog.Logger {
+			gotName = name
+			return globalLogger
+		}
+		ch := &channelImpl{logicalName: "ctrl", options: &Options{}}
+		assert.Same(t, globalLogger, ch.eventLogger())
+		assert.Equal(t, "ctrl", gotName, "LoggerFor should be keyed by the channel's logical name")
+	})
+
+	t.Run("default used when neither set", func(t *testing.T) {
+		LoggerFor = nil
+		ch := &channelImpl{logicalName: "agent", options: &Options{}}
+		assert.NotNil(t, ch.eventLogger())
+	})
+
+	t.Run("nil options falls back to LoggerFor", func(t *testing.T) {
+		LoggerFor = func(string) *slog.Logger { return globalLogger }
+		ch := &channelImpl{logicalName: "agent"}
+		assert.Same(t, globalLogger, ch.eventLogger())
+	})
+}

--- a/logging_test.go
+++ b/logging_test.go
@@ -17,6 +17,7 @@
 package channel
 
 import (
+	"io"
 	"log/slog"
 	"testing"
 
@@ -30,8 +31,11 @@ func TestEventLoggerResolution(t *testing.T) {
 	origLoggerFor := LoggerFor
 	defer func() { LoggerFor = origLoggerFor }()
 
-	optLogger := slog.New(slog.NewTextHandler(nil, nil))
-	globalLogger := slog.New(slog.NewTextHandler(nil, nil))
+	// Use io.Discard, not a nil writer: this test installs a logger into the
+	// package-global LoggerFor, which background channel-teardown goroutines
+	// from other tests may invoke. A nil-writer handler would panic when used.
+	optLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	globalLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
 	t.Run("Options.Logger wins over LoggerFor", func(t *testing.T) {
 		LoggerFor = func(string) *slog.Logger { return globalLogger }

--- a/logging_test.go
+++ b/logging_test.go
@@ -25,44 +25,35 @@ import (
 )
 
 // TestEventLoggerResolution verifies the lifecycle-logger precedence:
-// Options.Logger first, then the package-level LoggerFor, then a non-nil
-// default.
+// Options.Logger first, then the installed LoggerFor resolver, then a non-nil
+// default. It exercises the pure resolver with injected funcs rather than
+// mutating package state, so it never races background channel goroutines.
 func TestEventLoggerResolution(t *testing.T) {
-	origLoggerFor := LoggerFor
-	defer func() { LoggerFor = origLoggerFor }()
-
-	// Use io.Discard, not a nil writer: this test installs a logger into the
-	// package-global LoggerFor, which background channel-teardown goroutines
-	// from other tests may invoke. A nil-writer handler would panic when used.
 	optLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	globalLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	loggerFor := func(string) *slog.Logger { return globalLogger }
 
 	t.Run("Options.Logger wins over LoggerFor", func(t *testing.T) {
-		LoggerFor = func(string) *slog.Logger { return globalLogger }
-		ch := &channelImpl{logicalName: "link", options: &Options{Logger: optLogger}}
-		assert.Same(t, optLogger, ch.eventLogger())
+		got := resolveEventLogger(&Options{Logger: optLogger}, "link", loggerFor)
+		assert.Same(t, optLogger, got)
 	})
 
 	t.Run("LoggerFor used when Options.Logger nil", func(t *testing.T) {
 		var gotName string
-		LoggerFor = func(name string) *slog.Logger {
+		named := func(name string) *slog.Logger {
 			gotName = name
 			return globalLogger
 		}
-		ch := &channelImpl{logicalName: "ctrl", options: &Options{}}
-		assert.Same(t, globalLogger, ch.eventLogger())
+		got := resolveEventLogger(&Options{}, "ctrl", named)
+		assert.Same(t, globalLogger, got)
 		assert.Equal(t, "ctrl", gotName, "LoggerFor should be keyed by the channel's logical name")
 	})
 
 	t.Run("default used when neither set", func(t *testing.T) {
-		LoggerFor = nil
-		ch := &channelImpl{logicalName: "agent", options: &Options{}}
-		assert.NotNil(t, ch.eventLogger())
+		assert.NotNil(t, resolveEventLogger(&Options{}, "agent", nil))
 	})
 
 	t.Run("nil options falls back to LoggerFor", func(t *testing.T) {
-		LoggerFor = func(string) *slog.Logger { return globalLogger }
-		ch := &channelImpl{logicalName: "agent"}
-		assert.Same(t, globalLogger, ch.eventLogger())
+		assert.Same(t, globalLogger, resolveEventLogger(nil, "agent", loggerFor))
 	})
 }

--- a/logging_test.go
+++ b/logging_test.go
@@ -56,4 +56,10 @@ func TestEventLoggerResolution(t *testing.T) {
 	t.Run("nil options falls back to LoggerFor", func(t *testing.T) {
 		assert.Same(t, globalLogger, resolveEventLogger(nil, "agent", loggerFor))
 	})
+
+	t.Run("resolver returning nil falls back to default", func(t *testing.T) {
+		nilResolver := func(string) *slog.Logger { return nil }
+		assert.NotNil(t, resolveEventLogger(&Options{}, "agent", nilResolver),
+			"a resolver returning nil must not be cached; fall back to the default")
+	})
 }

--- a/options.go
+++ b/options.go
@@ -49,11 +49,11 @@ type Options struct {
 	MessageStrategy MessageStrategy
 
 	// Logger, when set, is the slog.Logger this channel uses for its lifecycle
-	// events. It takes precedence over the package-level LoggerFor, letting an
-	// owner give each channel (or channel type) its own logger and level
+	// events. It takes precedence over the resolver installed via SetLoggerFor,
+	// letting an owner give each channel (or channel type) its own logger and level
 	// control - e.g. an SDK context injecting its logger, or a router naming
 	// its link vs ctrl channels distinctly. When nil, the channel falls back
-	// to LoggerFor and then to the pfxlog default.
+	// to the SetLoggerFor resolver and then to the pfxlog default.
 	Logger *slog.Logger `json:"-"`
 }
 

--- a/options.go
+++ b/options.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"github.com/pkg/errors"
 	"io"
+	"log/slog"
 	"time"
 )
 
@@ -46,6 +47,14 @@ type Options struct {
 	ConnectOptions
 	WriteTimeout    time.Duration
 	MessageStrategy MessageStrategy
+
+	// Logger, when set, is the slog.Logger this channel uses for its lifecycle
+	// events. It takes precedence over the package-level LoggerFor, letting an
+	// owner give each channel (or channel type) its own logger and level
+	// control - e.g. an SDK context injecting its logger, or a router naming
+	// its link vs ctrl channels distinctly. When nil, the channel falls back
+	// to LoggerFor and then to the pfxlog default.
+	Logger *slog.Logger `json:"-"`
 }
 
 // DefaultOptions returns Options with sensible defaults.


### PR DESCRIPTION
This PR bundles two channel changes.

## 1. Require group secret only for multi-underlay channels (Fixes #267)

`NewSingleChannelWithUnderlay` panicked with `assignment to entry in nil map` when given an underlay whose `Headers()` returns nil (the websocket underlay), because it seeded a group secret by writing into that map. This surfaces in OpenZiti via `ziti fabric validate router-data-model` and other CLI commands that open a management channel over a websocket.

The group secret is a multi-underlay concept: it only matters for channels that dial or accept additional underlays. A simple single-underlay channel never reads it. This change requires the secret only for channels that can grow (those with a dial policy or constraints) and drops the seeding from `NewSingleChannelWithUnderlay`, so single-underlay channels over headerless underlays work without it.

## 2. Pluggable per-channel logging (Fixes #269)

Channel logged its lifecycle events through a single process-wide `pfxlog.Logger()`, so channel types (link/ctrl/sdk/agent) couldn't be distinguished or tuned independently, and there was no way to inject a logger per channel or per SDK context.

Adds a `log/slog`-based logger seam:

- `Options.Logger *slog.Logger` - primary per-channel logger.
- `LoggerFor func(name string) *slog.Logger` - package-level fallback, keyed by logical name.
- Default forwards to pfxlog/logrus, preserving existing behavior.

Resolution is `Options.Logger` -> `LoggerFor(logicalName)` -> pfxlog default. Underlay added/removed events now route through the resolved logger. Consumer-side wiring of type-named loggers is tracked as follow-up in #269.

Verified against the full channel suite (including multi-underlay dial/reconnect tests) and OpenZiti's controller/router channels, with per-channel-type log levels controllable at runtime via `ziti agent set-channel-log-level`.