### PR TITLE
Make MinTotalUnderlays first-class and add configurable reconnect jitter

### DIFF
--- a/dial_policy.go
+++ b/dial_policy.go
@@ -18,6 +18,7 @@ package channel
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"sync"
 	"time"
 
@@ -54,6 +55,14 @@ type BackoffConfig struct {
 	// If a dial is requested before this interval has elapsed since the last dial,
 	// the goroutine sleeps until the interval is satisfied.
 	MinDialInterval time.Duration
+	// Jitter is the maximum random fraction (0.0-1.0) of the computed backoff delay to subtract as
+	// jitter (default: 0, disabled). When many peers back off in lockstep off the same exponential
+	// schedule they re-dial simultaneously, producing a thundering herd on the destination. A
+	// non-zero Jitter spreads those redials by subtracting a random delay of up to Jitter*delay from
+	// the computed backoff, so the result falls within [(1-Jitter), 1]*delay. Subtracting rather than
+	// adding keeps the delay within MaxDelay while still spreading redials once the backoff reaches
+	// its cap. Values <= 0 disable jitter; values above 1.0 are capped at 1.0.
+	Jitter float64
 }
 
 // DefaultBackoffConfig provides sensible defaults for BackoffConfig.
@@ -133,6 +142,11 @@ func (self *BackoffDialPolicy) resetStaleFailures() {
 	}
 }
 
+// getBackoffDelay computes the delay before the next dial attempt. It is the exponential backoff
+// (baseDelay * 2^(failures-1), capped at MaxDelay), optionally with random jitter subtracted when
+// Backoff.Jitter is configured. Jitter spreads otherwise-synchronized redials across peers while
+// keeping the delay within MaxDelay; see BackoffConfig.Jitter. With no failures the delay is zero
+// and no jitter is applied.
 func (self *BackoffDialPolicy) getBackoffDelay() time.Duration {
 	self.mu.Lock()
 	defer self.mu.Unlock()
@@ -143,7 +157,18 @@ func (self *BackoffDialPolicy) getBackoffDelay() time.Duration {
 
 	// Exponential backoff: baseDelay * 2^(failures-1), capped at maxDelay
 	delay := self.Backoff.BaseDelay * (1 << min(self.consecutiveFailures-1, 30))
-	return min(delay, self.Backoff.MaxDelay)
+	delay = min(delay, self.Backoff.MaxDelay)
+
+	if jitter := self.Backoff.Jitter; jitter > 0 && delay > 0 {
+		if jitter > 1.0 {
+			jitter = 1.0
+		}
+		// subtract rather than add so the result stays within [(1-jitter), 1]*delay and never
+		// exceeds MaxDelay, while still spreading redials once the backoff reaches its cap.
+		delay -= time.Duration(rand.Float64() * jitter * float64(delay))
+	}
+
+	return delay
 }
 
 func (self *BackoffDialPolicy) recordSuccess() {

--- a/dial_policy_test.go
+++ b/dial_policy_test.go
@@ -67,6 +67,87 @@ func Test_BackoffDelay_CappedAtMaxDelay(t *testing.T) {
 	require.Equal(t, time.Second, p.getBackoffDelay())
 }
 
+func Test_BackoffDelay_NoJitterIsExact(t *testing.T) {
+	p := newTestPolicy()
+	require.Equal(t, float64(0), p.Backoff.Jitter, "default policy has jitter disabled")
+
+	// With jitter disabled the delay is exactly the exponential value on every call.
+	p.recordFailure()
+	for range 10 {
+		require.Equal(t, 100*time.Millisecond, p.getBackoffDelay())
+	}
+
+	p.recordFailure()
+	for range 10 {
+		require.Equal(t, 200*time.Millisecond, p.getBackoffDelay())
+	}
+}
+
+func Test_BackoffDelay_JitterWithinBoundsAndVaries(t *testing.T) {
+	p := newTestPolicy()
+	p.Backoff.Jitter = 0.5
+
+	p.recordFailure() // base * 2^0 = 100ms
+	base := 100 * time.Millisecond
+	minDelay := base - time.Duration(0.5*float64(base)) // jitter subtracts up to 0.5*base
+
+	seen := map[time.Duration]struct{}{}
+	for range 200 {
+		d := p.getBackoffDelay()
+		require.GreaterOrEqual(t, d, minDelay, "jitter never subtracts more than Jitter*delay")
+		require.LessOrEqual(t, d, base, "jitter only subtracts from the base delay")
+		seen[d] = struct{}{}
+	}
+	require.Greater(t, len(seen), 1, "jitter should produce varying delays")
+}
+
+func Test_BackoffDelay_JitterCappedAtOne(t *testing.T) {
+	p := newTestPolicy()
+	p.Backoff.Jitter = 5.0 // out of range, should clamp to 1.0
+
+	p.recordFailure() // base * 2^0 = 100ms
+	base := 100 * time.Millisecond
+
+	for range 200 {
+		d := p.getBackoffDelay()
+		require.GreaterOrEqual(t, d, time.Duration(0), "clamped jitter subtracts at most the full base delay")
+		require.LessOrEqual(t, d, base, "out-of-range jitter is capped at 1.0")
+	}
+}
+
+// Test_BackoffDelay_JitterStaysWithinMaxDelay verifies that once exponential backoff has reached
+// MaxDelay, jitter still varies the delay but never pushes it above MaxDelay. This is the case
+// where synchronized peers are all pinned at the cap and jitter must spread their redials without
+// violating the documented maximum.
+func Test_BackoffDelay_JitterStaysWithinMaxDelay(t *testing.T) {
+	p := newTestPolicy()
+	p.Backoff.Jitter = 0.5
+
+	// Drive failures well past the point where the exponential delay saturates MaxDelay.
+	for range 20 {
+		p.recordFailure()
+	}
+	maxDelay := p.Backoff.MaxDelay
+	minDelay := maxDelay - time.Duration(0.5*float64(maxDelay))
+
+	seen := map[time.Duration]struct{}{}
+	for range 200 {
+		d := p.getBackoffDelay()
+		require.LessOrEqual(t, d, maxDelay, "jitter must not extend the delay beyond MaxDelay at the cap")
+		require.GreaterOrEqual(t, d, minDelay, "jitter subtracts at most Jitter*MaxDelay")
+		seen[d] = struct{}{}
+	}
+	require.Greater(t, len(seen), 1, "jitter should still spread redials at the cap")
+}
+
+func Test_BackoffDelay_JitterNotAppliedWithoutFailures(t *testing.T) {
+	p := newTestPolicy()
+	p.Backoff.Jitter = 0.5
+
+	// No failures means no delay, and jitter must not turn a zero delay into a non-zero one.
+	require.Equal(t, time.Duration(0), p.getBackoffDelay())
+}
+
 func Test_RecordFailure_RecordsNegativeEvent(t *testing.T) {
 	p := newTestPolicy()
 

--- a/impl.go
+++ b/impl.go
@@ -69,7 +69,13 @@ type Config struct {
 	MessageSourceProvider MessageSourceProvider
 	DialPolicy            DialPolicy
 	Constraints           map[string]UnderlayConstraint
-	MinTotalUnderlays     int
+
+	// MinTotalUnderlays is the minimum number of underlays (across all types) the channel
+	// must keep open; it closes when the total drops below this. A positive value also makes
+	// the channel multi-underlay-capable, so it can be used on its own (without per-type
+	// constraints or a dial policy) for a channel that accepts additional underlays and
+	// closes only when its last one is lost.
+	MinTotalUnderlays int
 
 	// ConstraintStartupDelay delays the first constraint check after channel creation.
 	// Useful when the initial underlay needs time to stabilize before additional
@@ -246,12 +252,13 @@ func NewChannel(config *Config) (Channel, error) {
 
 	// The group secret matches reconnecting or additional underlays to this channel, so it is
 	// only required for channels that can grow: those with a dial policy (which dials more
-	// underlays) or constraints (which desire more). This mirrors the "simple channel"
-	// definition used elsewhere (no constraints and no dial policy). A simple single-underlay
-	// channel never dials or accepts additional underlays, so it needs no secret. Headers()
-	// may be nil, which indexes safely to a nil slice.
+	// underlays), constraints (which desire more), or a minimum total underlay count (which
+	// accepts more). This mirrors isMultiUnderlayCapable: a simple single-underlay channel never
+	// dials or accepts additional underlays, so it needs no secret. Without this, a secretless
+	// multi-underlay-capable channel would admit any secretless underlay, since bytes.Equal of two
+	// empty secrets is true. Headers() may be nil, which indexes safely to a nil slice.
 	impl.groupSecret = config.Underlay.Headers()[GroupSecretHeader]
-	if len(impl.groupSecret) == 0 && (config.DialPolicy != nil || len(config.Constraints) > 0) {
+	if len(impl.groupSecret) == 0 && (config.DialPolicy != nil || len(config.Constraints) > 0 || config.MinTotalUnderlays > 0) {
 		return nil, errors.New("no group secret header found for multi-underlay channel")
 	}
 
@@ -356,11 +363,12 @@ func (self *singleSenders) GetDefaultSender() Sender             { return self.s
 func (self *singleSenders) HandleTxFailed(string, Sendable) bool { return false }
 
 // isMultiUnderlayCapable reports whether this channel can grow beyond its
-// initial underlay. Only channels with a dial policy (which dials more
-// underlays) or constraints (which require or desire specific underlays) accept
-// or dial additional underlays; a simple channel never does.
+// initial underlay. Channels with a dial policy (which dials more underlays),
+// constraints (which require or desire specific underlay types), or a minimum
+// total underlay count accept or dial additional underlays; a simple channel
+// with none of these never does.
 func (self *channelImpl) isMultiUnderlayCapable() bool {
-	return self.dialPolicy != nil || len(self.constraints) > 0
+	return self.dialPolicy != nil || len(self.constraints) > 0 || self.minTotalUnderlays > 0
 }
 
 func (self *channelImpl) AcceptUnderlay(underlay Underlay) error {
@@ -734,7 +742,10 @@ func (self *channelImpl) UnderlayRemoved(ch Channel, underlay Underlay) {
 }
 
 func (self *channelImpl) applyConstraints() {
-	if len(self.constraints) == 0 {
+	// Nothing to enforce without per-type constraints or a minimum total. A channel
+	// with only minTotalUnderlays still needs this: countsShowValidState closes it
+	// when the total drops below the minimum.
+	if len(self.constraints) == 0 && self.minTotalUnderlays == 0 {
 		return
 	}
 

--- a/impl_test.go
+++ b/impl_test.go
@@ -90,6 +90,30 @@ func TestNewChannelMultiUnderlayRequiresGroupSecret(t *testing.T) {
 	require.Contains(t, err.Error(), "no group secret")
 }
 
+// TestNewChannelMinTotalUnderlaysRequiresGroupSecret verifies that MinTotalUnderlays alone makes
+// a channel multi-underlay-capable and so requires a group secret, matching isMultiUnderlayCapable.
+// Without the secret, the channel would admit any secretless underlay, since bytes.Equal of two
+// empty secrets is true.
+func TestNewChannelMinTotalUnderlaysRequiresGroupSecret(t *testing.T) {
+	ctx := NewSenderContext()
+	senders := &singleSenders{SenderContext: ctx, sender: NewSingleChSender(ctx, make(chan Sendable, 1))}
+	msgSource := NewSimpleMessageSourceProvider(func(*CloseNotifier) (Sendable, error) { return nil, io.EOF })
+
+	config := &Config{
+		LogicalName:           "test",
+		Underlay:              &testUnderlay{headers: nil},
+		Binder:                MakeBinder(BindHandlerF(func(Binding) error { return nil })),
+		Senders:               senders,
+		MessageSourceProvider: msgSource,
+		MinTotalUnderlays:     2,
+	}
+
+	ch, err := NewChannel(config)
+	require.Error(t, err)
+	require.Nil(t, ch)
+	require.Contains(t, err.Error(), "no group secret")
+}
+
 // TestSimpleChannelRejectsAdditionalUnderlays verifies that a simple channel (no
 // dial policy, no constraints) refuses additional underlays via AcceptUnderlay,
 // including a secretless one. Without the capability guard, a secretless simple

--- a/protobufs/protobufs.go
+++ b/protobufs/protobufs.go
@@ -23,11 +23,15 @@ import (
 	"reflect"
 )
 
+// TypedMessage is a proto.Message that carries its own channel content type, so it can be
+// marshalled into an Envelope without the caller supplying the type.
 type TypedMessage interface {
 	proto.Message
 	GetContentType() int32
 }
 
+// MarshalProto marshals msg into an Envelope with the given content type, returning an error
+// Envelope if marshalling fails.
 func MarshalProto(contentType int32, msg proto.Message) channel.Envelope {
 	b, err := proto.Marshal(msg)
 	if err != nil {
@@ -36,20 +40,27 @@ func MarshalProto(contentType int32, msg proto.Message) channel.Envelope {
 	return channel.NewMessage(contentType, b)
 }
 
+// MarshalTyped marshals a TypedMessage into an Envelope using the message's own content type.
 func MarshalTyped(msg TypedMessage) channel.Envelope {
 	return MarshalProto(msg.GetContentType(), msg)
 }
 
+// TypedResponse wraps a TypedMessage so a channel response can be unmarshalled into it with
+// content-type checking, via TypedResponseImpl.Unmarshall.
 func TypedResponse(message TypedMessage) TypedResponseImpl {
 	return TypedResponseImpl{
 		TypedMessage: message,
 	}
 }
 
+// TypedResponseImpl wraps a TypedMessage to unmarshal a channel response into it, verifying the
+// response's content type matches the expected type.
 type TypedResponseImpl struct {
 	TypedMessage
 }
 
+// Unmarshall unmarshals responseMsg into the wrapped TypedMessage. It returns err if non-nil, or
+// an error if the response content type does not match the expected type.
 func (self TypedResponseImpl) Unmarshall(responseMsg *channel.Message, err error) error {
 	if err != nil {
 		return err

--- a/underlays_test.go
+++ b/underlays_test.go
@@ -167,8 +167,10 @@ type testUnderlayListener struct {
 	removed []Underlay
 }
 
-func (l *testUnderlayListener) UnderlayAdded(_ Channel, u Underlay)   { l.added = append(l.added, u) }
-func (l *testUnderlayListener) UnderlayRemoved(_ Channel, u Underlay) { l.removed = append(l.removed, u) }
+func (l *testUnderlayListener) UnderlayAdded(_ Channel, u Underlay) { l.added = append(l.added, u) }
+func (l *testUnderlayListener) UnderlayRemoved(_ Channel, u Underlay) {
+	l.removed = append(l.removed, u)
+}
 
 type testUnderlayListenerF struct {
 	onAdded   func(Channel, Underlay)
@@ -210,4 +212,34 @@ func Test_applyConstraints_ClosesBelowMinEvenWhenApplyInProgress(t *testing.T) {
 	impl.applyConstraints()
 
 	require.True(t, impl.IsClosed(), "channel below min must close even while applyInProgress is held")
+}
+
+// Test_isMultiUnderlayCapable_MinTotalUnderlays verifies MinTotalUnderlays alone marks a
+// channel multi-underlay-capable, so a channel can accept additional underlays without
+// per-type constraints or a dial policy.
+func Test_isMultiUnderlayCapable_MinTotalUnderlays(t *testing.T) {
+	require.True(t, (&channelImpl{minTotalUnderlays: 1}).isMultiUnderlayCapable(),
+		"minTotalUnderlays > 0 should be multi-underlay-capable")
+	require.False(t, (&channelImpl{}).isMultiUnderlayCapable(),
+		"a channel with no dial policy, constraints, or minTotalUnderlays is simple")
+}
+
+// Test_applyConstraints_ClosesBelowMinTotalWithoutConstraints verifies that a channel with
+// only MinTotalUnderlays set (no per-type constraints, no dial policy) still closes when its
+// total underlay count drops below the minimum. This is the close-on-empty behavior a listener
+// relies on when it uses MinTotalUnderlays as its sole multi-underlay signal.
+func Test_applyConstraints_ClosesBelowMinTotalWithoutConstraints(t *testing.T) {
+	impl := &channelImpl{
+		minTotalUnderlays: 1,
+		underlays:         NewUnderlays(),
+		closeNotify:       make(chan struct{}),
+	}
+	var u Underlay = &testUnderlay{}
+	impl.fallbackUnderlay.Store(&u)
+
+	// No underlays remain, so the total (0) is below minTotalUnderlays (1). Even with no
+	// per-type constraints, applyConstraints must run the total check and close the channel.
+	impl.applyConstraints()
+
+	require.True(t, impl.IsClosed(), "channel below MinTotalUnderlays must close even with no per-type constraints")
 }


### PR DESCRIPTION
Two related control-channel reliability fixes.

## MinTotalUnderlays as a first-class multi-underlay signal (Fixes #271)

A channel configured with only `MinTotalUnderlays` (no per-type `Constraints`, no `DialPolicy`) didn't behave as multi-underlay: `isMultiUnderlayCapable()` ignored it so `AcceptUnderlay` rejected additional underlays, and `applyConstraints()` early-returned on empty constraints so the total-count check never ran. So `MinTotalUnderlays` was effectively a no-op on its own.

This makes it first-class: `isMultiUnderlayCapable()` accounts for it, and `applyConstraints()` runs the total check when it's set even with no per-type constraints. A listener can now pass just `MinTotalUnderlays: 1` to mean "accept additional underlays of any type, close only when the last is lost, never dial" - the v4 `SetMinTotal(1)` behavior.

OpenZiti control channels currently work around the gap with `Min: 0` constraints plus `MinTotalUnderlays: 1`; once this releases that workaround can be dropped.

## Configurable reconnect jitter for BackoffDialPolicy (Fixes #274)

`BackoffDialPolicy` computed its redial delay as pure exponential backoff off the consecutive-failure count. When many routers (hundreds) reconnect at once after a controller disruption, their delays line up and they redial in lockstep, producing a thundering herd on the controller. This was previously mitigated in ziti's v4 `DialCtrlChannel.DialFailed` (50% jitter), but the v5 dialing model moved redial timing into `BackoffDialPolicy`, which had no jitter, so the protection was lost in the channel-v5 migration.

Adds an opt-in `BackoffConfig.Jitter` (the max random fraction, 0.0-1.0, of the computed delay to add as jitter; 0 disables). `DefaultBackoffConfig` leaves it at 0 so existing callers are unaffected; callers like ziti's control channel opt in by setting it.
