### PR TITLE
Evict stale closed channels from the multi-listener registry

### DIFF
--- a/multi_listener.go
+++ b/multi_listener.go
@@ -19,6 +19,7 @@ package channel
 import (
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/michaelquigley/pfxlog"
@@ -31,10 +32,20 @@ type Factory func(underlay Underlay, closeCallback func()) (Channel, error)
 // UngroupedChannelFallback handles incoming underlays that are not part of a grouped connection.
 type UngroupedChannelFallback func(underlay Underlay) error
 
+// registration is the listener's record of a channel registered under a connection id.
+// Its pointer identity, rather than the Channel value, is what determines whether a close
+// callback still refers to the currently registered channel. Using the pointer avoids
+// comparing Channel interface values, which are not guaranteed to be comparable and would
+// use value rather than instance equality even when they are.
+type registration struct {
+	ch     Channel
+	closed atomic.Bool
+}
+
 // MultiListener routes incoming underlays to existing channels or creates new ones.
 // Grouped underlays are matched by connection ID; ungrouped ones are passed to the fallback.
 type MultiListener struct {
-	channels                 map[string]Channel
+	channels                 map[string]*registration
 	lock                     sync.Mutex
 	multiChannelFactory      Factory
 	ungroupedChannelFallback UngroupedChannelFallback
@@ -80,33 +91,70 @@ func (self *MultiListener) AcceptUnderlay(underlay Underlay, ackHello func() err
 	done := false
 	for !done {
 		var waitFor chan struct{}
-		self.lock.Lock()
 
-		ch, channelExists = self.channels[chId]
-		if channelExists {
-			done = true
-		} else {
-			var createLockExists bool
-			waitFor, createLockExists = self.createNotifiers[chId]
-			if !createLockExists {
-				if !isFirst {
-					// No channel and no create in progress for a non-first underlay: its group
-					// is gone (or this is a stale/old-iteration underlay). Close without acking
-					// so the dialer's create fails promptly rather than seeing a short-lived,
-					// acked-then-closed underlay. This cannot happen for a live reconnect: the
-					// group's first connection registers the notifier below before its own ack
-					// releases the dialer to dial these subsequent underlays.
-					self.lock.Unlock()
-					log.Info("no existing channel found for non-first underlay, closing connection")
-					if err := underlay.Close(); err != nil {
-						log.WithError(err).Error("error closing underlay")
-					}
-					return
-				}
-				createLockNotifier = make(chan struct{})
-				self.createNotifiers[chId] = createLockNotifier
-				done = true
+		// Channel methods must not be called while holding the listener lock. A channel may
+		// invoke its close callback while holding the same lock used by IsClosed, and that
+		// callback needs the listener lock to unregister the channel.
+		self.lock.Lock()
+		candidate, candidateExists := self.channels[chId]
+		self.lock.Unlock()
+
+		if candidateExists {
+			candidateClosed := candidate.closed.Load()
+			if !candidateClosed {
+				candidateClosed = candidate.ch.IsClosed()
 			}
+
+			self.lock.Lock()
+			current, stillExists := self.channels[chId]
+			if !stillExists || current != candidate {
+				// The registration changed while IsClosed ran. Retry rather than applying
+				// the result to a newer channel registered under the same id.
+				self.lock.Unlock()
+				continue
+			}
+			if !candidateClosed && !candidate.closed.Load() {
+				ch = candidate.ch
+				channelExists = true
+				done = true
+				self.lock.Unlock()
+				continue
+			}
+
+			// A stale closed channel is still registered for this id (it closed between
+			// setting its closed flag and its close callback running). Evict it so this
+			// underlay creates a fresh channel instead of being rejected indefinitely.
+			delete(self.channels, chId)
+		} else {
+			self.lock.Lock()
+			if _, nowExists := self.channels[chId]; nowExists {
+				// A registration appeared after the unlocked lookup. Retry and validate it.
+				self.lock.Unlock()
+				continue
+			}
+		}
+
+		// The listener lock is held here and the channel id is still unregistered.
+		var createLockExists bool
+		waitFor, createLockExists = self.createNotifiers[chId]
+		if !createLockExists {
+			if !isFirst {
+				// No channel and no create in progress for a non-first underlay: its group
+				// is gone (or this is a stale/old-iteration underlay). Close without acking
+				// so the dialer's create fails promptly rather than seeing a short-lived,
+				// acked-then-closed underlay. This cannot happen for a live reconnect: the
+				// group's first connection registers the notifier below before its own ack
+				// releases the dialer to dial these subsequent underlays.
+				self.lock.Unlock()
+				log.Info("no existing channel found for non-first underlay, closing connection")
+				if err := underlay.Close(); err != nil {
+					log.WithError(err).Error("error closing underlay")
+				}
+				return
+			}
+			createLockNotifier = make(chan struct{})
+			self.createNotifiers[chId] = createLockNotifier
+			done = true
 		}
 		self.lock.Unlock()
 		if waitFor != nil {
@@ -156,8 +204,12 @@ func (self *MultiListener) AcceptUnderlay(underlay Underlay, ackHello func() err
 	} else {
 		log.Info("no existing channel found for underlay")
 		var err error
+		// newReg identifies this specific channel in the map. The close callback captures it
+		// and evicts only this registration, so a stale callback can never remove a newer
+		// channel that reconnected under the same id.
+		newReg := &registration{}
 		ch, err = self.multiChannelFactory(underlay, func() {
-			self.CloseChannel(chId)
+			self.closeRegistration(chId, newReg)
 		})
 
 		if ch == nil && err == nil {
@@ -170,9 +222,27 @@ func (self *MultiListener) AcceptUnderlay(underlay Underlay, ackHello func() err
 				log.WithError(closeErr).Error("error closing underlay")
 			}
 		} else {
+			// Set and inspect the channel before publishing the registration. The callback's
+			// closed flag covers a close that races the IsClosed snapshot.
+			newReg.ch = ch
+			channelClosed := newReg.closed.Load()
+			if !channelClosed {
+				channelClosed = ch.IsClosed()
+			}
+
 			self.lock.Lock()
-			self.channels[chId] = ch
-			self.lock.Unlock()
+			if channelClosed || newReg.closed.Load() {
+				// The channel closed during creation (e.g. its only underlay dropped), and its
+				// close callback already ran before we could register it. Registering it now
+				// would leave a dead channel in the map that nothing removes, rejecting every
+				// future reconnect for this id. Skip it; the dialer will redial and create a
+				// fresh channel.
+				self.lock.Unlock()
+				log.Info("channel closed during creation, not registering")
+			} else {
+				self.channels[chId] = newReg
+				self.lock.Unlock()
+			}
 		}
 	}
 }
@@ -184,10 +254,24 @@ func (self *MultiListener) CloseChannel(chId string) {
 	self.lock.Unlock()
 }
 
+// closeRegistration removes reg from the listener's map, but only if it is still the
+// registration for chId. The identity check prevents a closing channel's callback from
+// evicting a newer channel that has already reconnected under the same id.
+func (self *MultiListener) closeRegistration(chId string, reg *registration) {
+	// Mark the token first so creation cannot publish it while this callback waits for the
+	// listener lock. This state is also safe to inspect without calling back into Channel.
+	reg.closed.Store(true)
+	self.lock.Lock()
+	if self.channels[chId] == reg {
+		delete(self.channels, chId)
+	}
+	self.lock.Unlock()
+}
+
 // NewMultiListener creates a MultiListener with the given channel factory and ungrouped fallback.
 func NewMultiListener(channelF Factory, fallback UngroupedChannelFallback) *MultiListener {
 	result := &MultiListener{
-		channels:                 make(map[string]Channel),
+		channels:                 make(map[string]*registration),
 		multiChannelFactory:      channelF,
 		ungroupedChannelFallback: fallback,
 		createNotifiers:          make(map[string]chan struct{}),

--- a/multi_listener_test.go
+++ b/multi_listener_test.go
@@ -219,6 +219,166 @@ func Test_MultiListener_CloseChannelRemovesFromMap(t *testing.T) {
 	require.False(t, exists)
 }
 
+// Test_MultiListener_CloseCallbackIgnoresStaleChannel verifies the identity check:
+// a close callback from an old channel must not evict a newer channel that has
+// reconnected under the same id.
+func Test_MultiListener_CloseCallbackIgnoresStaleChannel(t *testing.T) {
+	ml := NewMultiListener(func(underlay Underlay, closeCallback func()) (Channel, error) {
+		return &testChannel{connId: underlay.ConnectionId()}, nil
+	}, func(underlay Underlay) error {
+		return nil
+	})
+
+	ml.AcceptUnderlay(newGroupedTestUnderlay("conn-1", true), ackOK)
+	ml.lock.Lock()
+	current := ml.channels["conn-1"]
+	ml.lock.Unlock()
+	require.NotNil(t, current)
+
+	// A stale callback for a different registration under the same id must be a no-op.
+	ml.closeRegistration("conn-1", &registration{ch: &testChannel{connId: "conn-1"}})
+
+	ml.lock.Lock()
+	stillThere := ml.channels["conn-1"]
+	ml.lock.Unlock()
+	require.Same(t, current, stillThere, "current channel must not be evicted by a stale callback")
+}
+
+func Test_MultiListener_CloseCallbackSupportsNonComparableChannel(t *testing.T) {
+	var closeCallback func()
+	ml := NewMultiListener(func(underlay Underlay, callback func()) (Channel, error) {
+		closeCallback = callback
+		return nonComparableTestChannel{
+			testChannel: &testChannel{connId: underlay.ConnectionId()},
+			data:        []byte("not comparable"),
+		}, nil
+	}, func(underlay Underlay) error {
+		return errors.New("ungrouped not expected")
+	})
+
+	ml.AcceptUnderlay(newGroupedTestUnderlay("conn-1", true), ackOK)
+	require.NotNil(t, closeCallback)
+	require.NotPanics(t, closeCallback)
+
+	ml.lock.Lock()
+	_, exists := ml.channels["conn-1"]
+	ml.lock.Unlock()
+	require.False(t, exists, "close callback should remove a non-comparable channel")
+}
+
+func Test_MultiListener_IsClosedDoesNotDeadlockCloseCallback(t *testing.T) {
+	closeHasLock := make(chan struct{})
+	continueClose := make(chan struct{})
+	probeStarted := make(chan struct{})
+
+	var ch *mutexCloseTestChannel
+	ml := NewMultiListener(func(underlay Underlay, closeCallback func()) (Channel, error) {
+		ch = &mutexCloseTestChannel{
+			testChannel:   &testChannel{connId: underlay.ConnectionId()},
+			closeCallback: closeCallback,
+			closeHasLock:  closeHasLock,
+			continueClose: continueClose,
+			probeStarted:  probeStarted,
+		}
+		return ch, nil
+	}, func(underlay Underlay) error {
+		return errors.New("ungrouped not expected")
+	})
+
+	ml.AcceptUnderlay(newGroupedTestUnderlay("conn-1", true), ackOK)
+	ch.blockProbe.Store(true)
+
+	closeDone := make(chan struct{})
+	go func() {
+		defer close(closeDone)
+		_ = ch.Close()
+	}()
+	<-closeHasLock
+
+	lookupDone := make(chan struct{})
+	go func() {
+		defer close(lookupDone)
+		ml.AcceptUnderlay(newGroupedTestUnderlay("conn-1", false), ackOK)
+	}()
+	<-probeStarted
+
+	// Close calls its callback while holding the mutex needed by IsClosed. The callback
+	// can only finish if the concurrent lookup did not retain the listener lock.
+	close(continueClose)
+	select {
+	case <-closeDone:
+	case <-time.After(time.Second):
+		t.Fatal("channel close deadlocked against listener lookup")
+	}
+	select {
+	case <-lookupDone:
+	case <-time.After(time.Second):
+		t.Fatal("listener lookup did not finish after channel close")
+	}
+}
+
+// Test_MultiListener_ChannelClosedDuringCreationNotRegistered verifies the bug fix:
+// if a channel closes during creation (its close callback ran before it could be
+// registered), the listener must not register the dead channel, and a subsequent
+// reconnect for the same id must succeed with a fresh channel rather than being
+// rejected indefinitely.
+func Test_MultiListener_ChannelClosedDuringCreationNotRegistered(t *testing.T) {
+	returnClosed := true
+	ml := NewMultiListener(func(underlay Underlay, closeCallback func()) (Channel, error) {
+		ch := &testChannel{connId: underlay.ConnectionId(), closed: returnClosed}
+		if ch.closed {
+			// Mirror the real channel: its close callback runs when it closes, before
+			// the listener gets a chance to register it.
+			closeCallback()
+		}
+		return ch, nil
+	}, func(underlay Underlay) error {
+		return errors.New("ungrouped not expected")
+	})
+
+	// First underlay's channel closes during creation: it must not be registered.
+	ml.AcceptUnderlay(newGroupedTestUnderlay("conn-1", true), ackOK)
+	ml.lock.Lock()
+	_, exists := ml.channels["conn-1"]
+	ml.lock.Unlock()
+	require.False(t, exists, "a channel that closed during creation must not be registered")
+
+	// A subsequent reconnect (fresh, open channel) must succeed, not be rejected.
+	returnClosed = false
+	ml.AcceptUnderlay(newGroupedTestUnderlay("conn-1", true), ackOK)
+	ml.lock.Lock()
+	reg, exists := ml.channels["conn-1"]
+	ml.lock.Unlock()
+	require.True(t, exists, "reconnect after a close-during-creation must register a fresh channel")
+	require.False(t, reg.ch.IsClosed())
+}
+
+// Test_MultiListener_EvictsClosedChannelOnLookup verifies that if a closed channel is
+// somehow still registered, a new underlay for that id evicts it and creates a fresh
+// channel instead of being rejected.
+func Test_MultiListener_EvictsClosedChannelOnLookup(t *testing.T) {
+	ml := NewMultiListener(func(underlay Underlay, closeCallback func()) (Channel, error) {
+		return &testChannel{connId: underlay.ConnectionId()}, nil
+	}, func(underlay Underlay) error {
+		return errors.New("ungrouped not expected")
+	})
+
+	// Plant a stale closed channel directly in the map.
+	stale := &testChannel{connId: "conn-1", closed: true}
+	ml.lock.Lock()
+	ml.channels["conn-1"] = &registration{ch: stale}
+	ml.lock.Unlock()
+
+	ml.AcceptUnderlay(newGroupedTestUnderlay("conn-1", true), ackOK)
+
+	ml.lock.Lock()
+	reg := ml.channels["conn-1"]
+	ml.lock.Unlock()
+	require.NotNil(t, reg)
+	require.NotSame(t, Channel(stale), reg.ch, "stale closed channel should have been replaced")
+	require.False(t, reg.ch.IsClosed())
+}
+
 // Test_MultiListener_GroupReservedBeforeAck verifies the core ordering guarantee: when
 // a grouped first connection's hello is acknowledged, the group is already registered
 // (a channel or a create-in-progress notifier). The ack is what releases the dialer to
@@ -320,24 +480,70 @@ func Test_MultiListener_NonFirstAttachesWhileFirstInFlight(t *testing.T) {
 type testChannel struct {
 	connId      string
 	acceptCount int
+	closed      bool
 }
 
-func (c *testChannel) AcceptUnderlay(Underlay) error            { c.acceptCount++; return nil }
-func (c *testChannel) Id() string                               { return c.connId }
-func (c *testChannel) LogicalName() string                      { return "test" }
-func (c *testChannel) SetLogicalName(string)                    {}
-func (c *testChannel) ConnectionId() string                     { return c.connId }
-func (c *testChannel) Certificates() []*x509.Certificate        { return nil }
-func (c *testChannel) Label() string                            { return "test-ch" }
-func (c *testChannel) Send(Sendable) error                      { return nil }
-func (c *testChannel) TrySend(Sendable) (bool, error)           { return true, nil }
-func (c *testChannel) CloseNotify() <-chan struct{}              { return nil }
-func (c *testChannel) Close() error                             { return nil }
-func (c *testChannel) IsClosed() bool                           { return false }
-func (c *testChannel) Underlay() Underlay                       { return nil }
-func (c *testChannel) Headers() map[int32][]byte                { return nil }
-func (c *testChannel) GetTimeSinceLastRead() time.Duration      { return 0 }
-func (c *testChannel) GetUserData() any                         { return nil }
-func (c *testChannel) GetSenders() Senders                      { return nil }
-func (c *testChannel) GetUnderlays() []Underlay                 { return nil }
-func (c *testChannel) GetUnderlayCountsByType() map[string]int  { return nil }
+// nonComparableTestChannel is a valid value-backed Channel whose slice prevents
+// comparison when it is stored in an interface.
+type nonComparableTestChannel struct {
+	*testChannel
+	data []byte
+}
+
+// mutexCloseTestChannel models a Channel that protects IsClosed with the same mutex
+// held while Close invokes its listener callback.
+type mutexCloseTestChannel struct {
+	*testChannel
+	lock          sync.Mutex
+	closeCallback func()
+	closeHasLock  chan struct{}
+	continueClose chan struct{}
+	probeStarted  chan struct{}
+	blockProbe    atomic.Bool
+	probeOnce     sync.Once
+}
+
+func (c *mutexCloseTestChannel) Close() error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	close(c.closeHasLock)
+	<-c.continueClose
+	c.closed = true
+	c.closeCallback()
+	return nil
+}
+
+func (c *mutexCloseTestChannel) IsClosed() bool {
+	if c.blockProbe.Load() {
+		c.probeOnce.Do(func() { close(c.probeStarted) })
+	}
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.closed
+}
+
+func (c *testChannel) AcceptUnderlay(Underlay) error {
+	if c.closed {
+		return errors.New("new underlay not accepted: channel is closed")
+	}
+	c.acceptCount++
+	return nil
+}
+func (c *testChannel) Id() string                              { return c.connId }
+func (c *testChannel) LogicalName() string                     { return "test" }
+func (c *testChannel) SetLogicalName(string)                   {}
+func (c *testChannel) ConnectionId() string                    { return c.connId }
+func (c *testChannel) Certificates() []*x509.Certificate       { return nil }
+func (c *testChannel) Label() string                           { return "test-ch" }
+func (c *testChannel) Send(Sendable) error                     { return nil }
+func (c *testChannel) TrySend(Sendable) (bool, error)          { return true, nil }
+func (c *testChannel) CloseNotify() <-chan struct{}            { return nil }
+func (c *testChannel) Close() error                            { return nil }
+func (c *testChannel) IsClosed() bool                          { return c.closed }
+func (c *testChannel) Underlay() Underlay                      { return nil }
+func (c *testChannel) Headers() map[int32][]byte               { return nil }
+func (c *testChannel) GetTimeSinceLastRead() time.Duration     { return 0 }
+func (c *testChannel) GetUserData() any                        { return nil }
+func (c *testChannel) GetSenders() Senders                     { return nil }
+func (c *testChannel) GetUnderlays() []Underlay                { return nil }
+func (c *testChannel) GetUnderlayCountsByType() map[string]int { return nil }


### PR DESCRIPTION
Fixes #275

Under connection churn, a reconnecting grouped underlay could attach to a channel that was in the process of closing instead of forming a fresh one, because `MultiListener` keyed channels by connection id and there is a window between a channel setting its closed flag and its close callback deregistering it.

This closes that window three ways:

- the `Factory` close callback now receives the channel that closed, so a channel deregisters only the exact instance it created (never a newer channel that reused the id)
- a closed channel found on lookup is evicted so the underlay creates a fresh channel
- a channel that closes during creation is not registered

Surfaced while soak-testing control-channel churn; the distinct-per-iteration reconnect connection ids make the window reachable in practice. Includes regression tests for each case.