### PR TITLE
Accept int or float outQueueSize and a connectTimeout duration string

### DIFF
--- a/options.go
+++ b/options.go
@@ -19,10 +19,12 @@ package channel
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
 	"io"
 	"log/slog"
+	"math"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 // MessageStrategy provides pluggable message serialization and deserialization.
@@ -87,9 +89,29 @@ func LoadOptions(data map[interface{}]interface{}) (*Options, error) {
 // This allows callers to adjust defaults before loading configuration.
 func (o *Options) Load(data map[interface{}]interface{}) error {
 	if value, found := data["outQueueSize"]; found {
-		if floatValue, ok := value.(float64); ok {
-			o.OutQueueSize = int(floatValue)
+		// Accept both int and float64 (YAML decodes integers as int, JSON as
+		// float64), but reject values that are invalid as a channel buffer size:
+		// a negative size panics in make(chan ...), and fractional/out-of-range
+		// floats must be rejected rather than silently truncated.
+		var size int
+		switch v := value.(type) {
+		case int:
+			size = v
+		case float64:
+			if v != math.Trunc(v) {
+				return errors.Errorf("invalid outQueueSize %v: must be a whole number", v)
+			}
+			if v < math.MinInt || v > math.MaxInt {
+				return errors.Errorf("invalid outQueueSize %v: out of range", v)
+			}
+			size = int(v)
+		default:
+			return errors.Errorf("invalid outQueueSize (%T): expected a number", value)
 		}
+		if size < 0 {
+			return errors.Errorf("invalid outQueueSize %d: must not be negative", size)
+		}
+		o.OutQueueSize = size
 	}
 
 	if value, found := data["maxQueuedConnects"]; found {
@@ -104,7 +126,19 @@ func (o *Options) Load(data map[interface{}]interface{}) error {
 		}
 	}
 
-	if value, found := data["connectTimeoutMs"]; found {
+	// Prefer connectTimeout as a duration string (e.g. "5s"); fall back to the
+	// legacy connectTimeoutMs integer-millisecond form when it is not present.
+	if value, found := data["connectTimeout"]; found {
+		if strVal, ok := value.(string); ok {
+			d, err := time.ParseDuration(strVal)
+			if err != nil {
+				return errors.Wrapf(err, "invalid value for connectTimeout: %v", value)
+			}
+			o.ConnectTimeout = d
+		} else {
+			return errors.Errorf("invalid (non-string) value for connectTimeout: %v", value)
+		}
+	} else if value, found := data["connectTimeoutMs"]; found {
 		if intVal, ok := value.(int); ok {
 			o.ConnectTimeout = time.Duration(intVal) * time.Millisecond
 		}

--- a/options_test.go
+++ b/options_test.go
@@ -95,3 +95,69 @@ func TestLoadOptionsWriteTimeoutErrors(t *testing.T) {
 	req.Error(err)
 	req.Contains(err.Error(), "invalid value for writeTimeout")
 }
+
+func TestLoadOptionsOutQueueSizeAcceptsIntAndFloat(t *testing.T) {
+	req := require.New(t)
+
+	fromInt, err := LoadOptions(map[interface{}]interface{}{"outQueueSize": 42})
+	req.NoError(err)
+	req.Equal(42, fromInt.OutQueueSize)
+
+	fromFloat, err := LoadOptions(map[interface{}]interface{}{"outQueueSize": float64(42)})
+	req.NoError(err)
+	req.Equal(42, fromFloat.OutQueueSize)
+}
+
+func TestLoadOptionsOutQueueSizeRejectsInvalid(t *testing.T) {
+	req := require.New(t)
+
+	// Negative sizes would panic in make(chan ...); reject both int and float.
+	_, err := LoadOptions(map[interface{}]interface{}{"outQueueSize": -1})
+	req.Error(err)
+	req.Contains(err.Error(), "must not be negative")
+
+	_, err = LoadOptions(map[interface{}]interface{}{"outQueueSize": float64(-1)})
+	req.Error(err)
+
+	// Fractional floats are rejected rather than truncated.
+	_, err = LoadOptions(map[interface{}]interface{}{"outQueueSize": 1.5})
+	req.Error(err)
+	req.Contains(err.Error(), "whole number")
+
+	// Zero is valid (an unbuffered queue).
+	opts, err := LoadOptions(map[interface{}]interface{}{"outQueueSize": 0})
+	req.NoError(err)
+	req.Equal(0, opts.OutQueueSize)
+}
+
+func TestLoadOptionsConnectTimeout(t *testing.T) {
+	req := require.New(t)
+
+	// preferred duration-string form
+	opts, err := LoadOptions(map[interface{}]interface{}{"connectTimeout": "5s"})
+	req.NoError(err)
+	req.Equal(5*time.Second, opts.ConnectTimeout)
+
+	// legacy connectTimeoutMs still works as a fallback
+	legacy, err := LoadOptions(map[interface{}]interface{}{"connectTimeoutMs": 500})
+	req.NoError(err)
+	req.Equal(500*time.Millisecond, legacy.ConnectTimeout)
+
+	// connectTimeout wins when both are present
+	both, err := LoadOptions(map[interface{}]interface{}{
+		"connectTimeout":   "5s",
+		"connectTimeoutMs": 500,
+	})
+	req.NoError(err)
+	req.Equal(5*time.Second, both.ConnectTimeout)
+
+	// invalid duration string errors
+	_, err = LoadOptions(map[interface{}]interface{}{"connectTimeout": "not-a-duration"})
+	req.Error(err)
+	req.Contains(err.Error(), "invalid value for connectTimeout")
+
+	// non-string errors
+	_, err = LoadOptions(map[interface{}]interface{}{"connectTimeout": 123})
+	req.Error(err)
+	req.Contains(err.Error(), "invalid (non-string) value for connectTimeout")
+}


### PR DESCRIPTION
Makes `Options.Load` tolerant of how channel/link options are supplied, so callers can emit canonical option types instead of the historical float64 / integer-millisecond forms:

- `outQueueSize` is accepted as either an int (YAML) or a float64 (JSON). Negative, fractional, and out-of-range values are now rejected rather than silently accepted or truncated (a negative size would panic during channel creation).
- `connectTimeout` is accepted as a duration string (e.g. `5s`), taking precedence over and falling back to the legacy `connectTimeoutMs` integer-millisecond key for compatibility.